### PR TITLE
Stabilize tag game: fix tag-back cooldown bug + bot retry stalls

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -12,8 +12,15 @@ fi
 export PATH="$PATH:/c/Program Files/nodejs:/c/Program Files (x86)/nodejs"
 export PATH="$PATH:$APPDATA/npm:$HOME/AppData/Roaming/npm"
 
+# Git worktrees store .git as a *file* pointing to a gitdir path on the host
+# (outside the worktree). Containers that bind-mount the worktree can't reach
+# that path, so git - and therefore lint-staged - fails inside Docker. Run on
+# the host directly in that case.
+if [ -f ".git" ]; then
+    echo "⚠️ Git worktree detected. Running lint-staged on host."
+    npx lint-staged --no-stash --no-hide-partially-staged --config ./config/lint-staged.config.json
 # Prefer Docker if available; fallback to host lint-staged.
-if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+elif command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
     if ! docker compose -f config/docker-compose.yml ps app 2>/dev/null | grep -q 'running'; then
         echo "🦖 'app' container not running. Starting container..."
         docker compose -f config/docker-compose.yml up -d app

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,14 +1,38 @@
 # Tasks
 
-Last Updated: 2026-06-08
+Last Updated: 2026-06-11
 
 ## In Progress
 
-## Todo
+## Done
 
-- [ ] Review debug mode and regular tag logic for edge cases and regressions.
-- [ ] Diagnose and fix any remaining issues where the bot does not chase the player or where tagging is inconsistent in solo mode.
-- [ ] Ensure all tag cooldowns and freeze logic are respected for both player and bot, and that tag-back is impossible during cooldown.
+- [x] Review debug mode and regular tag logic for edge cases and regressions.
+  - Completed: 2026-06-11
+  - Evidence: new `src/__tests__/gameManager.edgeCases.test.ts` (8 tests) and a new
+    "blocks an immediate IT ping-pong..." case in
+    `src/pages/Solo/components/__tests__/Bots.test.tsx` cover tag-back cooldown, freeze
+    windows, self-tag rejection, score floor, restart/reset, and last-player-removed
+    edge cases. `Bots.tsx`'s debug logging was also migrated to the dev-gated
+    `createTagLogger`.
+
+- [x] Diagnose and fix any remaining issues where the bot does not chase the player or where tagging is inconsistent in solo mode.
+  - Completed: 2026-06-11
+  - Evidence: root cause was a blanket `lastTagTime` cooldown in `GameManager.tagPlayer`
+    that blocked a freshly-tagged IT player from tagging _anyone_ for 2s, compounded by
+    `useBotAI`'s 2000ms tag-retry gate. Fixed via a scoped `lastTaggedById`-based tag-back
+    cooldown (`src/components/GameManager.ts`) and a 200ms `TAG_RETRY_INTERVAL_MS` retry
+    loop (`src/components/characters/useBotAI.ts`); covered by 3 new tests in
+    `src/__tests__/useBotAI.unit.test.tsx`.
+
+- [x] Ensure all tag cooldowns and freeze logic are respected for both player and bot, and that tag-back is impossible during cooldown.
+  - Completed: 2026-06-11
+  - Evidence: `GameManager.tagPlayer` now enforces `TAG_BACK_COOLDOWN_MS` (2000ms, scoped
+    to the tagger/tagged pair via `lastTaggedById`) and `TAG_FREEZE_MS` (1500ms, blocks
+    anyone from re-tagging a just-tagged player), both reset cleanly on
+    `startTagGame`/`endGame`. Verified for player and bot — full Docker suite is 378
+    passed / 5 skipped, lint (`--max-warnings=0`) and `tsc --noEmit` both clean.
+
+## Todo
 
 - [ ] Stabilize mobile input and mobile layout on physical devices.
   - Priority: P0
@@ -59,6 +83,33 @@ Last Updated: 2026-06-08
   - Priority: P2
   - Problem: older refactor tasks no longer match the codebase hotspots.
   - Acceptance Criteria: only current, high-value refactors remain and each one ties back to reliability, testability, or performance.
+
+- [ ] **[Phase A] Pluggable game modes** — extract tag logic out of `GameManager` behind a `GameModeHandler` interface (`onStart`/`onTick`/`onAction`/`onEnd`), with a `TagMode` implementation preserving current behavior.
+  - Priority: P1
+  - Problem: tag rules (cooldowns, freeze, IT-transfer scoring) are hardcoded into `GameManager`, blocking deathmatch/CTF without risking regressions to tag.
+  - Acceptance Criteria: see `docs/MULTIPLAYER_SHOOTER_ROADMAP.md` Phase A; existing `gameManager.*.test.ts` and `Bots.test.tsx` pass unchanged.
+
+- [ ] **[Phase B] Combat primitives** — add `WeaponManager`, projectile/hit-detection (extends `CollisionSystem`), and `health`/`respawn` fields on `Player`.
+  - Priority: P2
+  - Problem: no weapon or damage model exists yet; required before any deathmatch/CTF mode.
+  - Acceptance Criteria: see `docs/MULTIPLAYER_SHOOTER_ROADMAP.md` Phase B.
+
+- [ ] **[Phase C] Deathmatch mode** — kill tracking, respawn, and scoreboard via `GameUI`.
+  - Priority: P2
+  - Acceptance Criteria: see `docs/MULTIPLAYER_SHOOTER_ROADMAP.md` Phase C.
+
+- [ ] **[Phase D] Capture the Flag mode** — teams, flag entities, and capture zones.
+  - Priority: P2
+  - Acceptance Criteria: see `docs/MULTIPLAYER_SHOOTER_ROADMAP.md` Phase D.
+
+- [ ] **[Phase E] Multiplayer shooter polish** — aiming camera, combat audio layer, and HUD additions for health/ammo/kills/flag status.
+  - Priority: P2
+  - Acceptance Criteria: see `docs/MULTIPLAYER_SHOOTER_ROADMAP.md` Phase E.
+
+- [ ] Fix server-side multiplayer tag parity before Multiplayer Tag ships.
+  - Priority: P1
+  - Problem: `server/index.js`'s `player-tagged` handler has no cooldown/freeze enforcement and trusts client-supplied tagger/tagged IDs, and its `disconnect` handler doesn't reassign or clear `itPlayerId` if the IT player disconnects.
+  - Acceptance Criteria: see `docs/MULTIPLAYER_SHOOTER_ROADMAP.md` "Server-side tag parity"; must be resolved before Multiplayer Tag moves out of `[planned]` in `FEATURES.md`.
 
 ## See also: docs/INSTRUCTIONS.md for agent handoff and workflow best practices.
 

--- a/docs/MULTIPLAYER_SHOOTER_ROADMAP.md
+++ b/docs/MULTIPLAYER_SHOOTER_ROADMAP.md
@@ -1,0 +1,166 @@
+# Multiplayer Shooter Roadmap — "Robot Conker's Bad Fur Day"
+
+**Status:** Phase 1 (tag stabilization) complete. This document defines Phase 2+.
+
+## Context
+
+`docs/CONKER_BFD_BUILD_GUIDE.md` is a generic implementation spec for a Conker's Bad Fur
+Day-style game (context-sensitive actions, weapons, deathmatch, CTF, race, etc.). This
+document translates that guide's relevant systems (Sections 5 and 9: Combat & Weapons,
+Multiplayer Modes) into concrete, Darkmoon-anchored next steps — i.e. what to actually
+change in _this_ codebase, in what order, building on the tag-mode foundation that now
+lives in `src/components/GameManager.ts` and `src/components/characters/useBotAI.ts`.
+
+Each phase below is a candidate for its own session/PR. Phases are ordered by
+dependency: A is a prerequisite for B–D; E can happen incrementally alongside B–D.
+
+---
+
+## Phase A — Pluggable Game Modes (prerequisite for everything else)
+
+**Why first:** `GameManager.tagPlayer`/`startTagGame`/`endGame`/`pickNewItPlayer` currently
+hardcode tag-specific rules (`TAG_BACK_COOLDOWN_MS`, `TAG_FREEZE_MS`, `lastTaggedById`,
+IT-transfer scoring) directly inside `GameManager`. Adding deathmatch or CTF by extending
+this class would tangle unrelated rule sets together, the same way the original tag-back
+bug tangled IT-transfer with cooldown state.
+
+**Plan:**
+
+- Define a small `GameModeHandler` interface (new file, e.g.
+  `src/components/gameModes/GameModeHandler.ts`):
+  ```ts
+  interface GameModeHandler {
+    onStart(players: Map<string, Player>, gameState: GameState): void;
+    onTick(deltaTime: number, gameState: GameState): void;
+    onAction(action: GameAction, gameState: GameState): boolean; // returns handled/accepted
+    onEnd(gameState: GameState): GameResult[];
+  }
+  ```
+- Extract the current tag rules into `src/components/gameModes/TagMode.ts`, implementing
+  `GameModeHandler`. `tagPlayer(taggerId, taggedId)` becomes an `onAction({ type: "tag",
+taggerId, taggedId })` call routed through the active mode.
+- `GameManager` becomes a thin host: owns `players`/`gameState`, holds the active
+  `GameModeHandler`, and delegates `startTagGame`/`tagPlayer`/`updateGameTimer`/`endGame`
+  to it. Keep the existing public method names/signatures so `Bots.tsx`,
+  `PlayerCharacter.tsx`, and `Solo.tsx` callers don't need to change.
+- `GameMode` union type (already `"none" | "tag" | "collectible" | "race" | "solo"`)
+  becomes the registry key for mode handlers.
+
+**Acceptance:**
+
+- `src/__tests__/gameManager.core.test.ts` and `gameManager.edgeCases.test.ts` pass
+  unchanged (or with mechanical updates only — no behavioral rewrites).
+- `Bots.test.tsx`'s "blocks an immediate IT ping-pong..." test still passes, proving
+  `TagMode` preserves the `lastTaggedById`/cooldown semantics from Phase 1.
+
+---
+
+## Phase B — Combat Primitives
+
+**Goal:** introduce the minimum weapon/damage model needed by Phases C and D.
+
+- **`WeaponManager`** (new: `src/components/combat/WeaponManager.ts`): registry of weapon
+  configs (`damage`, `range`, `cooldownMs`, `projectileSpeed`), `equip(weaponId)`,
+  `fire(originId, direction)`. Mirrors the registry pattern in the build guide's
+  `WeaponManager` (Section 5.2) but as plain TS (no Three.js scene mutation — that stays
+  in the React layer).
+- **Hit detection**: extend `src/components/CollisionSystem.ts` with a
+  `checkProjectileHit(origin, direction, range, players)` method that mirrors the existing
+  `checkPlayerCollision`-style proximity check used by tag's `tagDistance`, generalized to
+  a ray/cone instead of a fixed radius.
+- **`Player` additions** (`GameManager.ts`): `health?: number`, `maxHealth?: number`,
+  `respawnAt?: number`. Damage/respawn flow follows the same "mutate player, fire
+  callback" pattern as `tagPlayer`.
+- **Vertical slice**: one weapon (e.g. a short-range "stun blaster") wired into solo mode
+  as a toggle, reusing `SoundManager` for fire/hit SFX (`playTagSound`/`playTaggedSound`
+  are good templates for `playWeaponFireSound`/`playHitSound`).
+
+**Acceptance:**
+
+- New `src/__tests__/weaponManager.test.ts` covering cooldown/ammo/equip, following the
+  `makePlayer()` factory pattern from `gameManager.edgeCases.test.ts`.
+- New collision tests for `checkProjectileHit`, following the `mountHook`/collision-mock
+  pattern from `useBotAI.unit.test.tsx`'s "clamps flee movement..." test.
+
+---
+
+## Phase C — Deathmatch (maps to the build guide's `BeachMode`)
+
+- **`DeathmatchMode`** implements `GameModeHandler`: tracks `kills: Map<playerId,
+number>`, a `killLimit`, and a respawn timer (`respawnAt` from Phase B).
+- `onAction({ type: "hit", attackerId, targetId })`: apply damage via `WeaponManager`'s
+  configured damage; on `health <= 0`, increment `kills`, set `respawnAt`, zero `health`
+  for respawn.
+- **Scoreboard**: extend `GameUI.tsx`'s existing score display (it already renders
+  `gameState.scores`) to show `kills` per player when `mode === "deathmatch"`.
+
+**Acceptance:** regression tests for kill tracking, respawn timing, and end-of-game
+results, mirroring `endGame()`'s existing results-sorting test in
+`gameManager.core.test.ts`.
+
+---
+
+## Phase D — Capture the Flag (maps to the build guide's `HeistMode`)
+
+- **Teams**: add `team?: "a" | "b"` to `Player`. Team assignment happens in
+  `onStart` (alternate players, or balance by join order).
+- **Flag entities**: simple data objects `{ team: "a" | "b", position: [number, number,
+number], carrierId?: string }`, stored in `CTFMode` state (not on `Player`).
+- **Capture zones**: reuse the bounds-check pattern from the build guide's
+  `TriggerVolume` (Section 3.4) — a simple `containsPoint`-style check against each team's
+  base position, run in `onTick`.
+- `onAction({ type: "pickupFlag" | "captureFlag", playerId })` mutates flag
+  `carrierId`/`position` and increments `gameState.scores[team]` on capture.
+
+**Acceptance:** regression tests for pickup/capture/return sequences and the
+"can't capture your own team's flag" edge case.
+
+---
+
+## Phase E — Polish
+
+Incremental, can run alongside B–D:
+
+- **Camera**: `PlayerCharacter.tsx` already manages a follow camera; add an "aiming" mode
+  (over-the-shoulder offset, per build guide Section 10) when a weapon is equipped.
+- **Audio**: extend `musicLayers.ts`/`soundEffects.ts` with a combat music layer that
+  cross-fades in when `WeaponManager` reports recent fire/hit events, following the
+  existing layered-music approach in `SoundManager.startBackgroundMusic`.
+- **HUD**: `GameUI.tsx` gains health/ammo/kill/flag-status displays, gated by
+  `gameState.mode` so tag mode's HUD is unaffected.
+
+---
+
+## Server-side tag parity (must-fix before Multiplayer Tag ships)
+
+`FEATURES.md` lists Multiplayer Tag as `[planned]` (not live), so this is **not** a
+current blocker — but it must be resolved before that feature ships, since it would
+otherwise reintroduce the exact class of bug Phase 1 just fixed.
+
+**Found in `server/index.js`:**
+
+- The `player-tagged` handler (~lines 362–379) only checks
+  `data.taggerId === gameState.itPlayerId` and that both clients exist — it has **no**
+  equivalent of `TAG_BACK_COOLDOWN_MS` or `TAG_FREEZE_MS`, and trusts `data.taggedId` from
+  the client with no server-side distance/eligibility check.
+- The `disconnect` handler (~lines 393–409) deletes the disconnecting client from
+  `clients` but never checks whether `gameState.itPlayerId === client.id`. If the IT
+  player disconnects, `itPlayerId` keeps pointing at a non-existent client — no one can be
+  tagged again until `game-end`/`game-start` resets it.
+
+**Fix direction:** once Phase A lands, the server should hold a server-side
+`GameManager`/`TagMode` instance as the source of truth (mirrors the client-authoritative
+→ server-authoritative shift most multiplayer tag implementations need anyway), so the
+same cooldown/freeze/IT-reassignment logic runs in one place. At minimum, before shipping:
+port the `lastTaggedById`/cooldown/freeze checks into the `player-tagged` handler, and
+reassign or clear `itPlayerId` (mirroring `GameManager.pickNewItPlayer`'s zero-players
+branch) in the `disconnect` handler.
+
+---
+
+## Suggested sequencing
+
+`A → B → C → D`, with `E` woven in incrementally. Server-side tag parity should be
+addressed either as part of Phase A (if `TagMode` becomes shared client/server code) or
+as a standalone fix immediately before Multiplayer Tag moves from `[planned]` to
+`[in-progress]` in `FEATURES.md`.

--- a/src/__tests__/gameManager.edgeCases.test.ts
+++ b/src/__tests__/gameManager.edgeCases.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import GameManager, { type Player } from "../components/GameManager";
+
+const makePlayer = (id: string, name: string): Player => ({
+  id,
+  name,
+  position: [0, 0, 0],
+  rotation: [0, 0, 0],
+  isIt: false,
+  timeAsIt: 0,
+});
+
+describe("GameManager edge cases", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("allows a freshly-tagged IT player to tag a different player immediately", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+    manager.addPlayer(makePlayer("p3", "P3"));
+
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    vi.spyOn(Date, "now").mockReturnValue(10000);
+    manager.startTagGame(60);
+
+    const itId = manager.getGameState().itPlayerId!; // "p1"
+    const [target, third] = ["p1", "p2", "p3"].filter((id) => id !== itId);
+
+    // p1 tags p2 - p2 is now IT
+    expect(manager.tagPlayer(itId, target)).toBe(true);
+
+    // p2 (freshly IT) immediately tags p3 (an uninvolved player) - should
+    // succeed without waiting out the tag-back cooldown.
+    vi.spyOn(Date, "now").mockReturnValue(10100);
+    expect(manager.tagPlayer(target, third)).toBe(true);
+    expect(manager.getGameState().itPlayerId).toBe(third);
+  });
+
+  it("blocks an immediate tag-back of your tagger, then allows it once the cooldown elapses", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+    manager.addPlayer(makePlayer("p3", "P3"));
+
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    vi.spyOn(Date, "now").mockReturnValue(10000);
+    manager.startTagGame(60);
+
+    const itId = manager.getGameState().itPlayerId!; // "p1"
+    const [target] = ["p1", "p2", "p3"].filter((id) => id !== itId);
+
+    // p1 tags target - target is now IT and was tagged by p1
+    expect(manager.tagPlayer(itId, target)).toBe(true);
+
+    // Immediately tagging back p1 (the tagger) should be blocked
+    vi.spyOn(Date, "now").mockReturnValue(10100);
+    expect(manager.tagPlayer(target, itId)).toBe(false);
+    expect(manager.getGameState().itPlayerId).toBe(target);
+
+    // Once the tag-back cooldown (2000ms) has elapsed, the tag-back succeeds
+    vi.spyOn(Date, "now").mockReturnValue(12001);
+    expect(manager.tagPlayer(target, itId)).toBe(true);
+    expect(manager.getGameState().itPlayerId).toBe(itId);
+  });
+
+  it("rejects self-tag attempts", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    manager.startTagGame(60);
+
+    const itId = manager.getGameState().itPlayerId!;
+    expect(manager.tagPlayer(itId, itId)).toBe(false);
+  });
+
+  it("never awards a negative score even when timeAsIt exceeds MAX_TAG_SCORE", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    vi.spyOn(Date, "now").mockReturnValue(0);
+    manager.startTagGame(60);
+
+    const itId = manager.getGameState().itPlayerId!;
+    const otherId = itId === "p1" ? "p2" : "p1";
+
+    // Simulate a very slow tag, well past MAX_TAG_SCORE seconds
+    vi.spyOn(Date, "now").mockReturnValue(400000);
+    expect(manager.tagPlayer(itId, otherId)).toBe(true);
+    expect(manager.getGameState().scores[itId]).toBeGreaterThanOrEqual(0);
+  });
+
+  it("endGame is safe to call when the game was never started", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+
+    const results = manager.endGame();
+    expect(results).toEqual([{ id: "p1", name: "P1", score: 0 }]);
+    expect(manager.getGameState().isActive).toBe(false);
+  });
+
+  it("endGame is safe to call with no players", () => {
+    const manager = new GameManager();
+    expect(manager.endGame()).toEqual([]);
+  });
+
+  it("resets game state when the last player is removed during an active game", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    manager.startTagGame(60);
+
+    manager.removePlayer("p1");
+    manager.removePlayer("p2");
+
+    const state = manager.getGameState();
+    expect(state.isActive).toBe(false);
+    expect(state.itPlayerId).toBeUndefined();
+    expect(state.mode).toBe("none");
+  });
+
+  it("resets lastTagTime and lastTaggedById when restarting mid-game", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    vi.spyOn(Date, "now").mockReturnValue(1000);
+    manager.startTagGame(60);
+
+    const itId = manager.getGameState().itPlayerId!;
+    const otherId = itId === "p1" ? "p2" : "p1";
+    manager.tagPlayer(itId, otherId);
+
+    // Restart mid-game
+    manager.startTagGame(60);
+
+    for (const player of manager.getPlayers().values()) {
+      expect(player.lastTagTime).toBeUndefined();
+      expect(player.lastTaggedById).toBeUndefined();
+    }
+  });
+});

--- a/src/__tests__/useBotAI.unit.test.tsx
+++ b/src/__tests__/useBotAI.unit.test.tsx
@@ -187,4 +187,95 @@ describe("useBotAI", () => {
     frameCallback!(null, 1);
     expect(meshRef.current.position.x).toBe(xBefore);
   });
+
+  it("retries a tag attempt on a short interval while in range", () => {
+    const nowSpy = vi.spyOn(Date, "now");
+    nowSpy.mockReturnValue(5000);
+
+    const { onTagTarget } = mountHook({
+      targetPositionRef: { current: [0.1, 0, 0] },
+    });
+
+    frameCallback!(null, 0.016);
+    expect(onTagTarget).toHaveBeenCalledTimes(1);
+
+    // Same instant - e.g. GameManager rejected the tag due to a cooldown.
+    // The bot shouldn't spam onTagTarget every frame while waiting.
+    frameCallback!(null, 0.016);
+    expect(onTagTarget).toHaveBeenCalledTimes(1);
+
+    // Once the retry interval (200ms) elapses, the bot tries again.
+    nowSpy.mockReturnValue(5201);
+    frameCallback!(null, 0.016);
+    expect(onTagTarget).toHaveBeenCalledTimes(2);
+  });
+
+  it("cycles sprint bursts on and off based on sprintDuration/sprintCooldown", () => {
+    const nowSpy = vi.spyOn(Date, "now");
+    nowSpy.mockReturnValue(0);
+
+    // Keep the target far away so the bot stays in the chase branch
+    // (distance > tagDistance) for the whole test.
+    const { refs } = mountHook({
+      targetPositionRef: { current: [100, 0, 0] },
+    });
+
+    // t=0: first sprint burst begins immediately
+    frameCallback!(null, 0.016);
+    expect(refs.isSprinting.current).toBe(true);
+
+    // t=100: still within sprintDuration (200ms)
+    nowSpy.mockReturnValue(100);
+    frameCallback!(null, 0.016);
+    expect(refs.isSprinting.current).toBe(true);
+
+    // t=250: sprintDuration elapsed, sprintCooldown (500ms) not yet elapsed
+    nowSpy.mockReturnValue(250);
+    frameCallback!(null, 0.016);
+    expect(refs.isSprinting.current).toBe(false);
+
+    // t=699: still cooling down
+    nowSpy.mockReturnValue(699);
+    frameCallback!(null, 0.016);
+    expect(refs.isSprinting.current).toBe(false);
+
+    // t=700: cooldown elapsed, a new sprint burst begins
+    nowSpy.mockReturnValue(700);
+    frameCallback!(null, 0.016);
+    expect(refs.isSprinting.current).toBe(true);
+  });
+
+  it("clamps flee movement to the position returned by collision resolution", () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(5000);
+    void nowSpy;
+
+    // Simulate a wall blocking all movement - collision resolution returns
+    // the bot's current position unchanged instead of the requested newPos.
+    const blockingCollision: React.RefObject<CollisionSystem> = {
+      current: {
+        checkCollision: (from: THREE.Vector3) => ({
+          x: from.x,
+          y: from.y,
+          z: from.z,
+        }),
+        checkPlayerCollision: () => false,
+      } as unknown as CollisionSystem,
+    };
+
+    const { meshRef, onPositionUpdate } = mountHook({
+      isIt: false,
+      targetIsIt: true,
+      targetPositionRef: { current: [1, 0, 0] },
+      collisionSystem: blockingCollision,
+    });
+
+    const before = meshRef.current.position.clone();
+    frameCallback!(null, 1);
+
+    // Position is clamped to the collision-resolved value, not the naive
+    // flee target, so the bot doesn't clip through the wall.
+    expect(meshRef.current.position.x).toBeCloseTo(before.x);
+    expect(meshRef.current.position.z).toBeCloseTo(before.z);
+    expect(onPositionUpdate).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,5 +1,8 @@
 import React, { useState, useEffect } from "react";
 import { getSoundManager } from "./SoundManager";
+import { createLogger } from "../lib/utils/logger";
+
+const log = createLogger("ControlPanel");
 
 interface ControlPanelProps {
   onToggleChat?: () => void;
@@ -41,7 +44,7 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
         setIsMuted(soundMgr.getIsMuted());
       }
     } catch (error) {
-      console.warn("Sound manager not ready:", error);
+      log.warn("Sound manager not ready:", error);
     }
   };
 

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,4 +1,7 @@
-import React, { Component, ErrorInfo, ReactNode } from 'react';
+import React, { Component, ErrorInfo, ReactNode } from "react";
+import { createLogger } from "../lib/utils/logger";
+
+const log = createLogger("ErrorBoundary");
 
 interface Props {
   children: ReactNode;
@@ -21,7 +24,7 @@ class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('ErrorBoundary caught an error:', error, errorInfo);
+    log.error("ErrorBoundary caught an error:", error, errorInfo);
   }
 
   render() {
@@ -31,34 +34,36 @@ class ErrorBoundary extends Component<Props, State> {
       }
 
       return (
-        <div style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: '100vh',
-          width: '100%',
-          backgroundColor: '#1a1a1a',
-          color: '#fff',
-          padding: '20px',
-          textAlign: 'center',
-        }}>
-          <h1 style={{ fontSize: '48px', marginBottom: '20px' }}>🌑</h1>
-          <h2 style={{ marginBottom: '10px' }}>Something went wrong</h2>
-          <p style={{ marginBottom: '20px', opacity: 0.7 }}>
-            {this.state.error?.message || 'An unexpected error occurred'}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "100vh",
+            width: "100%",
+            backgroundColor: "#1a1a1a",
+            color: "#fff",
+            padding: "20px",
+            textAlign: "center",
+          }}
+        >
+          <h1 style={{ fontSize: "48px", marginBottom: "20px" }}>🌑</h1>
+          <h2 style={{ marginBottom: "10px" }}>Something went wrong</h2>
+          <p style={{ marginBottom: "20px", opacity: 0.7 }}>
+            {this.state.error?.message || "An unexpected error occurred"}
           </p>
           <button
             onClick={() => window.location.reload()}
             style={{
-              padding: '12px 24px',
-              backgroundColor: '#fff',
-              color: '#000',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: 'pointer',
-              fontSize: '16px',
-              fontWeight: 'bold',
+              padding: "12px 24px",
+              backgroundColor: "#fff",
+              color: "#000",
+              border: "none",
+              borderRadius: "4px",
+              cursor: "pointer",
+              fontSize: "16px",
+              fontWeight: "bold",
             }}
           >
             Reload Page

--- a/src/components/GameManager.ts
+++ b/src/components/GameManager.ts
@@ -27,6 +27,8 @@ export interface Player {
   isIt?: boolean;
   timeAsIt?: number;
   lastTagTime?: number;
+  /** ID of the player who most recently tagged this player (used for tag-back cooldown). */
+  lastTaggedById?: string;
 }
 
 export class GameManager {
@@ -40,6 +42,14 @@ export class GameManager {
   // Scoring constants
   private readonly MAX_TAG_SCORE = 300;
   private readonly MILLISECONDS_PER_SECOND = 1000;
+
+  // Tag cooldown constants
+  // Prevents a player who was just tagged (and is now IT) from instantly
+  // tagging back the player who tagged them.
+  private readonly TAG_BACK_COOLDOWN_MS = 2000;
+  // Prevents a player who was just tagged from being tagged again by anyone
+  // (gives them a moment to react/move before becoming a target again).
+  private readonly TAG_FREEZE_MS = 1500;
 
   constructor() {
     this.gameState = {
@@ -115,6 +125,7 @@ export class GameManager {
       player.isIt = id === this.gameState.itPlayerId;
       player.timeAsIt = 0;
       player.lastTagTime = undefined;
+      player.lastTaggedById = undefined;
     });
 
     this.callbacks.onGameStateUpdate?.(this.gameState);
@@ -124,7 +135,7 @@ export class GameManager {
       log.debug(
         `Tag game started! ${
           this.players.get(this.gameState.itPlayerId)?.name
-        } is IT!`
+        } is IT!`,
       );
     } else {
       log.debug(`Tag game started (solo practice)`);
@@ -133,7 +144,9 @@ export class GameManager {
   }
 
   tagPlayer(taggerId: string, taggedId: string): boolean {
-    log.debug(`[TAG-TRACE] tagPlayer called with taggerId=${taggerId}, taggedId=${taggedId}`);
+    log.debug(
+      `[TAG-TRACE] tagPlayer called with taggerId=${taggerId}, taggedId=${taggedId}`,
+    );
     if (this.gameState.mode !== "tag" || !this.gameState.isActive) {
       log.debug(`[TAG-TRACE] Tag failed: Not in tag mode or inactive`);
       return false;
@@ -143,19 +156,34 @@ export class GameManager {
     const tagged = this.players.get(taggedId);
 
     if (!tagger || !tagged || !tagger.isIt || tagged.isIt) {
-      log.debug(`[TAG-TRACE] Tag failed: tagger or tagged missing, or tagger not IT, or tagged already IT`, { tagger, tagged });
+      log.debug(
+        `[TAG-TRACE] Tag failed: tagger or tagged missing, or tagger not IT, or tagged already IT`,
+        { tagger, tagged },
+      );
       return false;
     }
 
     // Check if enough time has passed since last tag (prevent spam)
     const now = Date.now();
-    if (tagger.lastTagTime && now - tagger.lastTagTime < 2000) {
-      log.debug(`[TAG-TRACE] Tag failed: tagger cooldown (${now - tagger.lastTagTime}ms < 2000ms)`);
+    // Prevent a player who was just tagged (and is now IT) from instantly
+    // tagging back the player who tagged them. This is scoped to the
+    // specific tagger/tagged pair so a freshly-tagged IT player can still
+    // chase down a *different* player immediately.
+    if (
+      tagger.lastTaggedById === taggedId &&
+      tagger.lastTagTime &&
+      now - tagger.lastTagTime < this.TAG_BACK_COOLDOWN_MS
+    ) {
+      log.debug(
+        `[TAG-TRACE] Tag failed: tag-back cooldown (${now - tagger.lastTagTime}ms < ${this.TAG_BACK_COOLDOWN_MS}ms)`,
+      );
       return false;
     }
-    // Prevent the new IT from tagging back instantly (freeze/cooldown)
-    if (tagged.lastTagTime && now - tagged.lastTagTime < 1500) {
-      log.debug(`[TAG-TRACE] Tag failed: tagged freeze/cooldown (${now - tagged.lastTagTime}ms < 1500ms)`);
+    // Prevent the new IT from being tagged again immediately (freeze/cooldown)
+    if (tagged.lastTagTime && now - tagged.lastTagTime < this.TAG_FREEZE_MS) {
+      log.debug(
+        `[TAG-TRACE] Tag failed: tagged freeze/cooldown (${now - tagged.lastTagTime}ms < ${this.TAG_FREEZE_MS}ms)`,
+      );
       return false;
     }
 
@@ -164,7 +192,7 @@ export class GameManager {
     if (this.gameState.scores[taggerId] !== undefined) {
       this.gameState.scores[taggerId] += Math.max(
         0,
-        this.MAX_TAG_SCORE - timeAsIt / this.MILLISECONDS_PER_SECOND
+        this.MAX_TAG_SCORE - timeAsIt / this.MILLISECONDS_PER_SECOND,
       ); // Points based on how quickly they tagged
     }
 
@@ -173,6 +201,7 @@ export class GameManager {
     tagger.lastTagTime = now;
     tagged.isIt = true;
     tagged.lastTagTime = now;
+    tagged.lastTaggedById = taggerId;
 
     this.gameState.itPlayerId = taggedId;
     this.gameState.roundStartTime = now;
@@ -180,7 +209,7 @@ export class GameManager {
     this.callbacks.onGameStateUpdate?.(this.gameState);
     this.callbacks.onPlayerUpdate?.(this.players);
     log.debug(
-      `${tagger.name} tagged ${tagged.name}! ${tagged.name} is now IT!`
+      `${tagger.name} tagged ${tagged.name}! ${tagged.name} is now IT!`,
     );
     return true;
   }
@@ -217,6 +246,7 @@ export class GameManager {
       player.isIt = false;
       player.timeAsIt = 0;
       player.lastTagTime = undefined;
+      player.lastTaggedById = undefined;
     });
 
     this.callbacks.onGameStateUpdate?.(this.gameState);
@@ -231,7 +261,15 @@ export class GameManager {
   }
 
   private pickNewItPlayer() {
-    if (this.players.size === 0) return;
+    if (this.players.size === 0) {
+      // No players remain; there is nothing to tag, so end the round
+      // entirely rather than leaving a dangling itPlayerId/isActive state.
+      this.gameState.isActive = false;
+      this.gameState.mode = "none";
+      this.gameState.itPlayerId = undefined;
+      this.callbacks.onGameStateUpdate?.(this.gameState);
+      return;
+    }
 
     const newItId = this.pickRandomPlayer();
     this.gameState.itPlayerId = newItId;

--- a/src/components/SoundManager.ts
+++ b/src/components/SoundManager.ts
@@ -9,6 +9,10 @@ import { applyVolumes } from "./soundHelpers";
 import { createOscillatorWithGain } from "./soundNodeFactory";
 import * as soundEffects from "./soundEffects";
 import { createBackgroundMusic } from "./musicLayers";
+import { createLogger } from "../lib/utils/logger";
+
+const log = createLogger("SoundManager");
+
 class SoundManager {
   private audioContext: AudioContext | null = null;
   private backgroundMusic: OscillatorNode | null = null;
@@ -59,8 +63,9 @@ class SoundManager {
       const WindowWithAudio = window as Window & {
         webkitAudioContext?: typeof AudioContext;
       };
-      this.audioContext = new (window.AudioContext ||
-        WindowWithAudio.webkitAudioContext!)();
+      this.audioContext = new (
+        window.AudioContext || WindowWithAudio.webkitAudioContext!
+      )();
 
       // Create gain nodes for volume control
       this.musicGain = this.audioContext.createGain();
@@ -71,7 +76,7 @@ class SoundManager {
       this.sfxGain.gain.value = this.sfxVolume;
       this.sfxGain.connect(this.audioContext.destination);
     } catch (error) {
-      console.error("Failed to initialize audio context:", error);
+      log.error("Failed to initialize audio context:", error);
     }
   }
 
@@ -97,7 +102,7 @@ class SoundManager {
       // Use helper to build music layers and get oscillators
       const { masterGain, oscillators } = createBackgroundMusic(
         ctx,
-        musicGain!
+        musicGain!,
       );
 
       // Start oscillators
@@ -128,7 +133,7 @@ class SoundManager {
         const fadeOutTime = 4.0;
         musicGain.gain.linearRampToValueAtTime(
           0,
-          ctx.currentTime + fadeOutTime
+          ctx.currentTime + fadeOutTime,
         );
 
         // Stop after fade completes
@@ -264,7 +269,7 @@ class SoundManager {
       return soundEffects.playJetpackThrustSoundImpl(
         ctx,
         sfxGain,
-        this.sfxVolume
+        this.sfxVolume,
       );
     } catch {
       return null;
@@ -278,7 +283,7 @@ class SoundManager {
     thrustSound: {
       osc: OscillatorNode;
       gain: GainNode;
-    } | null
+    } | null,
   ) {
     const ctx = this.getAudioContext();
     if (!thrustSound || !ctx) return;
@@ -306,7 +311,7 @@ class SoundManager {
       gain.gain.value = 0;
       gain.gain.linearRampToValueAtTime(
         this.sfxVolume * 0.25,
-        ctx.currentTime + 0.01
+        ctx.currentTime + 0.01,
       );
       gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.08);
 
@@ -334,13 +339,13 @@ class SoundManager {
       const { osc, gain } = createOscillatorWithGain(
         ctx,
         "sine",
-        120 + Math.random() * 30
+        120 + Math.random() * 30,
       );
 
       gain.gain.value = 0;
       gain.gain.linearRampToValueAtTime(
         this.sfxVolume * 0.35,
-        ctx.currentTime + 0.01
+        ctx.currentTime + 0.01,
       );
       gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.12);
 
@@ -375,7 +380,7 @@ class SoundManager {
       gain.gain.value = 0;
       gain.gain.linearRampToValueAtTime(
         this.sfxVolume * 0.6 * impact,
-        ctx.currentTime + 0.01
+        ctx.currentTime + 0.01,
       );
       gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.2);
 
@@ -436,7 +441,7 @@ class SoundManager {
       this.musicVolume,
       this.sfxVolume,
       this.masterVolume,
-      this.isMuted
+      this.isMuted,
     );
   }
 

--- a/src/components/SpacemanModel.tsx
+++ b/src/components/SpacemanModel.tsx
@@ -135,7 +135,7 @@ const SpacemanModel: React.FC<SpacemanModelProps> = ({
       headGroupRef.current.rotation.y = THREE.MathUtils.clamp(
         newRotation,
         -maxHeadRotation,
-        maxHeadRotation
+        maxHeadRotation,
       );
     }
 
@@ -160,7 +160,7 @@ const SpacemanModel: React.FC<SpacemanModelProps> = ({
   });
 
   return (
-    <group scale={0.5} rotation={[0, Math.PI, 0]} position={[0, -0.35, 0]}>
+    <group scale={0.5} rotation={[0, Math.PI, 0]} position={[0, 0.1, 0]}>
       {/* Body - cylinder */}
       <mesh castShadow position={[0, 0.6, 0]}>
         <cylinderGeometry args={[0.3, 0.35, 0.8, 16]} />

--- a/src/components/UtilityMenu.tsx
+++ b/src/components/UtilityMenu.tsx
@@ -2,6 +2,9 @@ import React, { useState, useEffect } from "react";
 import { getSoundManager } from "./SoundManager";
 import { QualityLevel } from "./QualitySettings";
 import { useTheme } from "../contexts/ThemeContext";
+import { createLogger } from "../lib/utils/logger";
+
+const log = createLogger("UtilityMenu");
 
 interface UtilityMenuProps {
   onToggleChat?: () => void;
@@ -21,7 +24,7 @@ const UtilityMenu: React.FC<UtilityMenuProps> = ({
   const [showQualityMenu, setShowQualityMenu] = useState(false);
   const [isMobile, setIsMobile] = useState(window.innerWidth <= 768);
   const [isLandscape, setIsLandscape] = useState(
-    window.innerWidth > window.innerHeight
+    window.innerWidth > window.innerHeight,
   );
   const { theme, toggleTheme } = useTheme();
 
@@ -54,7 +57,7 @@ const UtilityMenu: React.FC<UtilityMenuProps> = ({
         setIsMuted(soundMgr.getIsMuted());
       }
     } catch (error) {
-      console.warn("Sound manager not ready:", error);
+      log.warn("Sound manager not ready:", error);
     }
   };
 
@@ -123,7 +126,7 @@ const UtilityMenu: React.FC<UtilityMenuProps> = ({
               >
                 {level === "auto" ? "Auto (Recommended)" : level}
               </button>
-            )
+            ),
           )}
         </div>
       )}

--- a/src/components/characters/PlayerCharacter.tsx
+++ b/src/components/characters/PlayerCharacter.tsx
@@ -146,7 +146,6 @@ export const PlayerCharacter = React.forwardRef<
   const [showJetpackFlame, setShowJetpackFlame] = useState(false);
   const lookIndicatorRef = React.useRef<THREE.Group>(null);
 
-
   // Expose reset and freeze functions to parent via ref
   React.useImperativeHandle(ref, () => ({
     resetPosition: () => {
@@ -266,7 +265,7 @@ export const PlayerCharacter = React.forwardRef<
       // Clamp vertical rotation
       cameraRotationRef.current.vertical = Math.max(
         -Math.PI / 3,
-        Math.min(Math.PI / 3, cameraRotationRef.current.vertical)
+        Math.min(Math.PI / 3, cameraRotationRef.current.vertical),
       );
 
       previousMouseRef.current.x = mouseControls.mouseX;
@@ -296,7 +295,7 @@ export const PlayerCharacter = React.forwardRef<
     // Always clamp vertical rotation (from joystick too)
     cameraRotationRef.current.vertical = Math.max(
       -Math.PI / 3,
-      Math.min(Math.PI / 3, cameraRotationRef.current.vertical)
+      Math.min(Math.PI / 3, cameraRotationRef.current.vertical),
     );
 
     // Calculate camera offset based on rotation
@@ -346,7 +345,7 @@ export const PlayerCharacter = React.forwardRef<
         const lookForward = new THREE.Vector3(
           -Math.sin(cameraRotationRef.current.horizontal),
           0,
-          -Math.cos(cameraRotationRef.current.horizontal)
+          -Math.cos(cameraRotationRef.current.horizontal),
         );
         const lookDistance = 6;
         const lookPos = meshRef.current.position
@@ -358,7 +357,7 @@ export const PlayerCharacter = React.forwardRef<
         lookIndicatorRef.current.rotation.set(
           -Math.PI / 2,
           0,
-          -cameraRotationRef.current.horizontal
+          -cameraRotationRef.current.horizontal,
         );
       } else {
         lookIndicatorRef.current.visible = false;
@@ -377,7 +376,7 @@ export const PlayerCharacter = React.forwardRef<
           Q: keysPressedRef.current[Q],
           E: keysPressedRef.current[E],
         },
-        bothMouseButtons
+        bothMouseButtons,
       );
 
       if (dir && dir.length() > 0) {
@@ -394,7 +393,7 @@ export const PlayerCharacter = React.forwardRef<
         const resolvedPosition = resolveMovement(
           collisionSystemRef.current,
           currentPosition,
-          newPosition
+          newPosition,
         );
 
         // Player collision + tagging logic handled by helper
@@ -409,7 +408,7 @@ export const PlayerCharacter = React.forwardRef<
                 detectPlayerCollision(
                   collisionSystemRef.current,
                   resolvedPosition,
-                  otherPlayerPos
+                  otherPlayerPos,
                 )
               ) {
                 const pushDirection = resolvedPosition
@@ -464,12 +463,12 @@ export const PlayerCharacter = React.forwardRef<
           directionRef.current,
           cameraRotationRef.current.horizontal,
           isAiming,
-          meshRef.current.rotation.y
+          meshRef.current.rotation.y,
         );
         meshRef.current.rotation.y = THREE.MathUtils.lerp(
           meshRef.current.rotation.y,
           targetYaw,
-          0.2
+          0.2,
         );
 
         // Emit position to server
@@ -541,11 +540,7 @@ export const PlayerCharacter = React.forwardRef<
     }
 
     // Apply jetpack thrust while space is held (only if jetpack active)
-    if (
-      jetpackActiveRef.current &&
-      isJumpingRef.current &&
-      isSprinting
-    ) {
+    if (jetpackActiveRef.current && isJumpingRef.current && isSprinting) {
       if (jumpHoldTimeRef.current < PHYSICS_CONSTANTS.JETPACK_MAX_HOLD_TIME) {
         jumpHoldTimeRef.current += delta;
         // Compute thrust using helper
@@ -606,10 +601,12 @@ export const PlayerCharacter = React.forwardRef<
         if (keysPressedRef.current[A]) rcsDirection.x += 1;
         if (keysPressedRef.current[D]) rcsDirection.x -= 1;
         if (keysPressedRef.current[Q]) {
-          verticalVelocityRef.current += PHYSICS_CONSTANTS.RCS_THRUST * delta * 2;
+          verticalVelocityRef.current +=
+            PHYSICS_CONSTANTS.RCS_THRUST * delta * 2;
         }
         if (keysPressedRef.current[E]) {
-          verticalVelocityRef.current -= PHYSICS_CONSTANTS.RCS_THRUST * delta * 2;
+          verticalVelocityRef.current -=
+            PHYSICS_CONSTANTS.RCS_THRUST * delta * 2;
         }
 
         // Play RCS sound when input is active (throttle to ~10 times per second)
@@ -633,7 +630,9 @@ export const PlayerCharacter = React.forwardRef<
             -cameraRotationRef.current.horizontal,
           );
           horizontalMomentumRef.current.add(
-            rcsDirection.multiplyScalar(PHYSICS_CONSTANTS.RCS_THRUST * delta * 10),
+            rcsDirection.multiplyScalar(
+              PHYSICS_CONSTANTS.RCS_THRUST * delta * 10,
+            ),
           );
         }
       }
@@ -652,7 +651,7 @@ export const PlayerCharacter = React.forwardRef<
 
       // Preserve horizontal momentum with slight decay
       horizontalMomentumRef.current.multiplyScalar(
-        PHYSICS_CONSTANTS.MOMENTUM_PRESERVATION
+        PHYSICS_CONSTANTS.MOMENTUM_PRESERVATION,
       );
 
       // Allow some air control - blend player input with momentum
@@ -703,7 +702,7 @@ export const PlayerCharacter = React.forwardRef<
     if (onPositionUpdate && meshRef.current) {
       const currentPos = meshRef.current.position;
       const distanceMoved = currentPos.distanceTo(
-        lastReportedPositionRef.current
+        lastReportedPositionRef.current,
       );
 
       if (distanceMoved > POSITION_UPDATE_THRESHOLD) {
@@ -716,7 +715,7 @@ export const PlayerCharacter = React.forwardRef<
     idealCameraPositionRef.current.set(
       meshRef.current.position.x + cameraOffsetRef.current.x,
       meshRef.current.position.y + cameraOffsetRef.current.y,
-      meshRef.current.position.z + cameraOffsetRef.current.z
+      meshRef.current.position.z + cameraOffsetRef.current.z,
     );
 
     // Lerp camera position for smooth following
@@ -733,7 +732,7 @@ export const PlayerCharacter = React.forwardRef<
     state.camera.lookAt(
       meshRef.current.position.x,
       meshRef.current.position.y + 0.5,
-      meshRef.current.position.z
+      meshRef.current.position.z,
     );
   });
 
@@ -760,11 +759,7 @@ export const PlayerCharacter = React.forwardRef<
       return (
         <mesh
           key={i}
-          position={[
-            Math.cos(angle) * radius,
-            0.1,
-            Math.sin(angle) * radius,
-          ]}
+          position={[Math.cos(angle) * radius, 0.1, Math.sin(angle) * radius]}
         >
           <sphereGeometry args={[0.05, 8, 8]} />
           <meshBasicMaterial color="#999999" opacity={0.6} transparent />
@@ -786,7 +781,7 @@ export const PlayerCharacter = React.forwardRef<
       />
       {/* Jetpack thrust visual effect */}
       {showJetpackFlame && (
-        <group position={[0, -0.5, 0]}>
+        <group position={[0, -0.05, 0]}>
           <mesh rotation={[Math.PI, 0, 0]}>
             <coneGeometry args={[0.15, 0.4, 8]} />
             <meshStandardMaterial
@@ -810,9 +805,7 @@ export const PlayerCharacter = React.forwardRef<
         </group>
       )}
       {/* Landing dust effect */}
-      {showDustEffect && (
-        <group position={[0, -0.4, 0]}>{dustMeshes}</group>
-      )}
+      {showDustEffect && <group position={[0, 0.05, 0]}>{dustMeshes}</group>}
       {/* Debug hitbox visualization */}
       {props.showHitboxes && (
         <mesh position={[0, 0, 0]}>

--- a/src/components/characters/useBotAI.ts
+++ b/src/components/characters/useBotAI.ts
@@ -12,6 +12,12 @@ const tagDebug = createTagLogger("BotAI");
 // This makes the game more playable by allowing the chasing bot to successfully tag fleeing bots
 const FLEE_SPEED_MULTIPLIER = 0.7;
 
+// How often the bot retries a tag attempt while in range. The actual tag
+// cooldown/freeze rules are enforced authoritatively by GameManager.tagPlayer,
+// so this only needs to be short enough to avoid stalling once that cooldown
+// elapses (it is intentionally much shorter than GameManager's cooldowns).
+const TAG_RETRY_INTERVAL_MS = 200;
+
 export interface BotConfig {
   botSpeed: number;
   sprintSpeed: number;
@@ -111,7 +117,9 @@ export function useBotAI({
         tagDebug(`[${config.label}] Freeze ended at ${now}, isIt: ${isIt}`);
         // After pause, check if bot is now IT and should chase
         if (isIt) {
-          tagDebug(`[${config.label}] Bot is now IT after pause, will chase player.`);
+          tagDebug(
+            `[${config.label}] Bot is now IT after pause, will chase player.`,
+          );
         }
       } else {
         // Bot is frozen, show visual indicator by slightly pulsing scale
@@ -136,7 +144,12 @@ export function useBotAI({
     lastPosition.current.copy(currentPosVec);
 
     // Behavior depends on who is IT (only during active tag games)
-    if (isIt && gameState.isActive && gameState.mode === "tag" && !isPausedAfterTag.current) {
+    if (
+      isIt &&
+      gameState.isActive &&
+      gameState.mode === "tag" &&
+      !isPausedAfterTag.current
+    ) {
       // Bot is IT - chase target
       if (distance > config.tagDistance) {
         // Sprint burst logic - IT bot sprints more aggressively
@@ -185,18 +198,22 @@ export function useBotAI({
         // Rotate bot to face target
         const angle = Math.atan2(direction.x, direction.z);
         meshRef.current.rotation.y = angle;
-      } else if (now - lastTagTime.current > config.tagCooldown) {
-        // Tag the target!
+      } else if (now - lastTagTime.current > TAG_RETRY_INTERVAL_MS) {
+        // In range - attempt to tag. GameManager.tagPlayer is the
+        // authoritative gate (cooldowns/freeze), so just retry on a short
+        // interval until it succeeds.
         tagDebug(
-          `🤖 ${config.label} TAGGING TARGET! Distance: ${distance.toFixed(
-            2,
-          )}, Cooldown elapsed: ${now - lastTagTime.current}ms`,
+          `🤖 ${config.label} ATTEMPTING TAG! Distance: ${distance.toFixed(2)}`,
         );
         lastTagTime.current = now;
-        tagDebug(`  ${config.label} continues moving (no freeze for tagger)`);
         onTagTarget();
       }
-    } else if (targetIsIt && gameState.isActive && gameState.mode === "tag" && !isPausedAfterTag.current) {
+    } else if (
+      targetIsIt &&
+      gameState.isActive &&
+      gameState.mode === "tag" &&
+      !isPausedAfterTag.current
+    ) {
       // Target is IT - flee when within detection radius
       // Non-IT bot moves SLOWER so it can be caught (for debugging)
       if (distance < config.chaseRadius) {

--- a/src/lib/hooks/__tests__/usePlayerTagging.test.ts
+++ b/src/lib/hooks/__tests__/usePlayerTagging.test.ts
@@ -105,7 +105,7 @@ describe("usePlayerTagging.processTagging", () => {
     // Spy on tagPlayer
     const tagSpy = vi.spyOn(
       gameManager as unknown as { tagPlayer?: (...args: unknown[]) => boolean },
-      "tagPlayer"
+      "tagPlayer",
     );
     tagSpy.mockImplementation(() => true);
 
@@ -129,5 +129,91 @@ describe("usePlayerTagging.processTagging", () => {
     expect(tagged).toBe(true);
     expect(tagSpy).toHaveBeenCalled();
     expect(socketClient!.emit).toHaveBeenCalled();
+  });
+
+  it("records cooldown/freeze state on GameManager so the newly-tagged bot can't immediately tag back", () => {
+    gameManager.startTagGame(60);
+
+    // Force p1 to be IT for test determinism
+    const itId = gameManager.getGameState().itPlayerId as string;
+    gameManager.updatePlayer(itId, { isIt: false });
+    gameManager.updatePlayer("p1", { isIt: true });
+    gameManager.getGameState().itPlayerId = "p1";
+
+    clients = {
+      "bot-1": { position: [0.4, 0, 0] },
+    };
+
+    const tagged = processTagging({
+      resolvedPosition: new THREE.Vector3(0, 0, 0),
+      clients,
+      myId: "p1",
+      gameManager,
+      lastTagCheckRef,
+      playerIsIt: true,
+      setPlayerIsIt: vi.fn(),
+      setBotIsIt: vi.fn(),
+      setBot1GotTagged: vi.fn(),
+      setBot2GotTagged: undefined,
+      setGameState: vi.fn(),
+      onTagSuccess: undefined,
+      socketClient:
+        socketClient as unknown as import("socket.io-client").Socket,
+    });
+
+    expect(tagged).toBe(true);
+
+    const p1 = gameManager.getPlayers().get("p1")!;
+    const bot1 = gameManager.getPlayers().get("bot-1")!;
+    expect(p1.isIt).toBe(false);
+    expect(bot1.isIt).toBe(true);
+    expect(bot1.lastTaggedById).toBe("p1");
+    expect(bot1.lastTagTime).toBeDefined();
+
+    // Bot-1 immediately tagging p1 back must be rejected by the freeze
+    // window - otherwise the player gets incorrectly frozen right after
+    // performing a successful tag.
+    expect(gameManager.tagPlayer("bot-1", "p1")).toBe(false);
+  });
+
+  it("does not update React state when GameManager rejects the tag (e.g. tagged player still frozen)", () => {
+    gameManager.startTagGame(60);
+
+    const itId = gameManager.getGameState().itPlayerId as string;
+    gameManager.updatePlayer(itId, { isIt: false });
+    gameManager.updatePlayer("p1", { isIt: true });
+    gameManager.getGameState().itPlayerId = "p1";
+
+    // bot-1 was tagged moments ago and is still within TAG_FREEZE_MS
+    gameManager.updatePlayer("bot-1", { lastTagTime: Date.now() });
+
+    clients = {
+      "bot-1": { position: [0.4, 0, 0] },
+    };
+
+    const setPlayerIsIt = vi.fn();
+    const setBotIsIt = vi.fn();
+
+    const tagged = processTagging({
+      resolvedPosition: new THREE.Vector3(0, 0, 0),
+      clients,
+      myId: "p1",
+      gameManager,
+      lastTagCheckRef,
+      playerIsIt: true,
+      setPlayerIsIt,
+      setBotIsIt,
+      setBot1GotTagged: vi.fn(),
+      setBot2GotTagged: undefined,
+      setGameState: vi.fn(),
+      onTagSuccess: undefined,
+      socketClient:
+        socketClient as unknown as import("socket.io-client").Socket,
+    });
+
+    expect(tagged).toBe(false);
+    expect(setPlayerIsIt).not.toHaveBeenCalled();
+    expect(setBotIsIt).not.toHaveBeenCalled();
+    expect(gameManager.getPlayers().get("p1")!.isIt).toBe(true);
   });
 });

--- a/src/lib/hooks/usePlayerTagging.ts
+++ b/src/lib/hooks/usePlayerTagging.ts
@@ -68,11 +68,23 @@ export function processTagging(params: TaggingParams): boolean {
       now - lastTagCheckRef.current > 1000;
 
     if (canTag) {
+      // GameManager.tagPlayer is the authoritative gate: it enforces the
+      // tag-back cooldown and tagged-player freeze window, and (on success)
+      // updates isIt/lastTagTime/lastTaggedById/itPlayerId itself. Call it
+      // first and only sync local state if it actually transferred "it" -
+      // otherwise a cooldown-blocked attempt would desync React state from
+      // GameManager (e.g. marking the player not-IT while GameManager still
+      // considers them IT).
+      if (
+        typeof gameManager.tagPlayer !== "function" ||
+        !gameManager.tagPlayer(myId, clientId)
+      ) {
+        continue;
+      }
 
       if (setGameState) {
         setGameState((prev) => ({ ...prev, itPlayerId: clientId }));
       }
-
 
       // Update IT state for React state sync (for test and UI correctness)
       if (clientId === "bot-1") {
@@ -103,15 +115,6 @@ export function processTagging(params: TaggingParams): boolean {
           taggerId: myId,
           taggedId: clientId,
         });
-      }
-
-      // Update game manager state
-      if (gameManager) {
-        gameManager.updatePlayer(myId, { isIt: false });
-        gameManager.updatePlayer(clientId, { isIt: true });
-        if (typeof gameManager.tagPlayer === "function") {
-          gameManager.tagPlayer(myId, clientId);
-        }
       }
 
       lastTagCheckRef.current = now;

--- a/src/pages/Solo.tsx
+++ b/src/pages/Solo.tsx
@@ -2,19 +2,11 @@ import * as React from "react";
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { type Socket } from "socket.io-client";
 import type { Clients } from "../types/socket";
-import PerformanceMonitor from "../components/PerformanceMonitor";
-import UtilityMenu from "../components/UtilityMenu";
-import Tutorial from "../components/Tutorial";
-import HelpModal from "../components/HelpModal";
-import ChatBox from "../components/ChatBox";
 import CollisionSystem from "../components/CollisionSystem";
 import SoloHUD from "./Solo/components/SoloHUD";
 import GameManager, { GameState, Player } from "../components/GameManager";
-import GameUI from "../components/GameUI";
-import { MobileControls } from "../components/MobileControls";
 import type { PlayerCharacterHandle } from "../components/characters/PlayerCharacter";
 import "../styles/App.css";
-import PauseMenu from "../components/PauseMenu";
 import { useNavigate } from "react-router-dom";
 import { filterProfanity } from "../lib/constants/profanity";
 import { createTagLogger } from "../lib/utils/logger";
@@ -594,9 +586,6 @@ const Solo: React.FC = () => {
         overflow: "hidden",
       }}
     >
-      <Tutorial />
-      <HelpModal />
-
       <SoloScene
         qualitySettings={qualitySettings}
         rockPositions={rockPositions}
@@ -658,103 +647,7 @@ const Solo: React.FC = () => {
         setChatVisible={setChatVisible}
         chatMessages={chatMessages}
         onSendMessage={handleSendMessage}
-      />
-
-      {/* Mobile Controls */}
-      {isMobileDevice && (
-        <MobileControls
-          onJoystickMove={(x, y) => setJoystickMove({ x, y })}
-          onJumpPress={() => setKeyState(SPACE, true)}
-          onJumpRelease={() => setKeyState(SPACE, false)}
-          onJumpDoubleTap={() => {
-            mobileJetpackTrigger.current = true;
-            setKeyState(SPACE, true);
-          }}
-          onSprintPress={() => setKeyState(SHIFT, true)}
-          onSprintRelease={() => setKeyState(SHIFT, false)}
-        />
-      )}
-
-      {/* Game UI Overlay */}
-      <GameUI
-        gameState={gameState}
-        players={gamePlayers}
-        currentPlayerId={currentPlayerId}
-        onStartGame={handleStartTagGame}
-        onEndGame={handleEndGame}
-        botDebugMode={botDebugMode}
-        onToggleDebug={() => setBotDebugMode((prev) => !prev)}
-      />
-
-      {/* Notifications */}
-      <div
-        style={{
-          position: "fixed",
-          top: "180px",
-          right: "10px",
-          zIndex: 2000,
-          display: "flex",
-          flexDirection: "column",
-          gap: "10px",
-          pointerEvents: "none",
-          maxWidth: "300px",
-        }}
-      >
-        {notifications.map((notification) => (
-          <div
-            key={notification.id}
-            style={{
-              padding: "12px 16px",
-              backgroundColor:
-                notification.type === "success"
-                  ? "rgba(0, 200, 0, 0.9)"
-                  : notification.type === "warning"
-                    ? "rgba(255, 165, 0, 0.9)"
-                    : notification.type === "error"
-                      ? "rgba(200, 0, 0, 0.9)"
-                      : "rgba(74, 144, 226, 0.9)",
-              color: "white",
-              borderRadius: "6px",
-              fontFamily: "monospace",
-              fontSize: "14px",
-              border: "1px solid rgba(255, 255, 255, 0.3)",
-              boxShadow: "0 4px 6px rgba(0, 0, 0, 0.3)",
-              animation: "slideIn 0.3s ease-out",
-              minWidth: "200px",
-              textAlign: "center",
-            }}
-          >
-            {notification.message}
-          </div>
-        ))}
-      </div>
-
-      {/* Performance Monitor */}
-      <PerformanceMonitor onPerformanceChange={setCurrentFPS} />
-
-      {/* Utility Menu (Mute, Quality Settings, Chat) */}
-      <UtilityMenu
-        onToggleChat={() => setChatVisible(!chatVisible)}
-        isChatVisible={chatVisible}
-        currentFPS={currentFPS}
-        onQualityChange={setQuality}
-      />
-
-      {/* Pause Menu */}
-      <PauseMenu
-        isVisible={isPaused}
-        onResume={handleResumeGame}
-        onRestart={() => window.location.reload()}
-        onQuit={handleQuitGame}
-      />
-
-      {/* Chat Box */}
-      <ChatBox
-        isVisible={chatVisible}
-        onToggle={() => setChatVisible(!chatVisible)}
-        messages={chatMessages}
-        onSendMessage={handleSendMessage}
-        currentPlayerId={currentPlayerId}
+        onPerformanceChange={setCurrentFPS}
       />
     </div>
   );

--- a/src/pages/Solo/components/Bots.tsx
+++ b/src/pages/Solo/components/Bots.tsx
@@ -2,6 +2,9 @@ import React, { useCallback } from "react";
 import { BotCharacter } from "../../../components/characters/BotCharacter";
 import type { SoloSceneProps } from "./SoloScene.types";
 import type { BotConfig as FullBotConfig } from "../../../components/characters/useBotAI";
+import { createTagLogger } from "../../../lib/utils/logger";
+
+const tagDebug = createTagLogger("Bots");
 
 const Bots: React.FC<
   Pick<
@@ -20,10 +23,10 @@ const Bots: React.FC<
     | "gameManager"
     | "gameState"
     | "setBot1GotTagged"
-      | "setBot2GotTagged"
-      | "currentPlayerId"
-      | "playerIsIt"
-      | "playerPositionRef"
+    | "setBot2GotTagged"
+    | "currentPlayerId"
+    | "playerIsIt"
+    | "playerPositionRef"
   >
 > = ({
   botDebugMode,
@@ -81,22 +84,22 @@ const Bots: React.FC<
   // Debug: Log IT state changes
   React.useEffect(() => {
     // Only log when IT state changes
-    console.log(
-      `[DEBUG] bot1IsIt: ${bot1IsIt}, bot2IsIt: ${bot2IsIt}, playerIsIt: ${playerIsItFromManager}`
+    tagDebug(
+      `bot1IsIt: ${bot1IsIt}, bot2IsIt: ${bot2IsIt}, playerIsIt: ${playerIsItFromManager}`,
     );
   }, [bot1IsIt, bot2IsIt, playerIsItFromManager]);
 
   // Bot tag callbacks - handle bot-to-bot tagging
 
   const handleBot1TagTarget = useCallback(() => {
-    console.log("[BOT-TAG-DEBUG] handleBot1TagTarget called", {
+    tagDebug("handleBot1TagTarget called", {
       bot1IsIt,
       isActive: gameState.isActive,
       mode: gameState.mode,
       currentPlayerId,
       playerIsItFromManager,
       bot2IsIt,
-      botDebugMode
+      botDebugMode,
     });
     if (
       !gameManager ||
@@ -104,7 +107,7 @@ const Bots: React.FC<
       !gameState.isActive ||
       gameState.mode !== "tag"
     ) {
-      console.log("[BOT-TAG-DEBUG] Bot1 cannot tag:", {
+      tagDebug("Bot1 cannot tag:", {
         bot1IsIt,
         isActive: gameState.isActive,
         mode: gameState.mode,
@@ -116,20 +119,23 @@ const Bots: React.FC<
     const targetIsAlreadyIt = botDebugMode ? bot2IsIt : playerIsItFromManager;
 
     if (!targetIsAlreadyIt) {
-      console.log(`[BOT-TAG-DEBUG] Bot1 attempting to tag ${targetId}`);
+      tagDebug(`Bot1 attempting to tag ${targetId}`);
       const result = gameManager.tagPlayer("bot-1", targetId);
-      console.log(`[BOT-TAG-DEBUG] gameManager.tagPlayer('bot-1', ${targetId}) returned:`, result);
-        if (result) {
-          if (botDebugMode) {
-            setBot2GotTagged(Date.now());
-          } else if (targetId === currentPlayerId && typeof window !== "undefined") {
-            // Trigger player freeze/cooldown after being tagged by bot
-            const event = new window.Event("player-tagged-by-bot");
-            window.dispatchEvent(event);
-          }
+      tagDebug(`gameManager.tagPlayer('bot-1', ${targetId}) returned:`, result);
+      if (result) {
+        if (botDebugMode) {
+          setBot2GotTagged(Date.now());
+        } else if (
+          targetId === currentPlayerId &&
+          typeof window !== "undefined"
+        ) {
+          // Trigger player freeze/cooldown after being tagged by bot
+          const event = new window.Event("player-tagged-by-bot");
+          window.dispatchEvent(event);
         }
+      }
     } else {
-      console.log(`[BOT-TAG-DEBUG] Bot1 target (${targetId}) is already IT, cannot tag.`);
+      tagDebug(`Bot1 target (${targetId}) is already IT, cannot tag.`);
     }
   }, [
     gameManager,
@@ -152,12 +158,9 @@ const Bots: React.FC<
 
   return (
     <>
-
       <BotCharacter
         targetPositionRef={
-          botDebugMode
-            ? bot2PositionRef
-            : playerPositionRef // Always use the live player position ref, updated every frame
+          botDebugMode ? bot2PositionRef : playerPositionRef // Always use the live player position ref, updated every frame
         }
         isIt={bot1IsIt}
         targetIsIt={botDebugMode ? bot2IsIt : playerIsItFromManager}
@@ -166,14 +169,16 @@ const Bots: React.FC<
           const windowWithPlayerFreeze =
             typeof window === "undefined"
               ? undefined
-              : (window as typeof globalThis & { __playerFreezeUntil?: number });
+              : (window as typeof globalThis & {
+                  __playerFreezeUntil?: number;
+                });
 
           // Prevent tag if player is frozen/cooldown
           if (
             windowWithPlayerFreeze?.__playerFreezeUntil &&
             Date.now() < windowWithPlayerFreeze.__playerFreezeUntil
           ) {
-            console.log("[BOT-TAG-DEBUG] Player is frozen/cooldown, cannot tag");
+            tagDebug("Player is frozen/cooldown, cannot tag");
             return;
           }
           handleBot1TagTarget();

--- a/src/pages/Solo/components/SoloHUD.tsx
+++ b/src/pages/Solo/components/SoloHUD.tsx
@@ -38,6 +38,7 @@ interface SoloHUDProps {
   setChatVisible: (v: boolean) => void;
   chatMessages: ChatMessage[];
   onSendMessage: (message: string) => void;
+  onPerformanceChange: (fps: number) => void;
 }
 
 const SoloHUD: React.FC<SoloHUDProps> = ({
@@ -66,6 +67,7 @@ const SoloHUD: React.FC<SoloHUDProps> = ({
   setChatVisible,
   chatMessages,
   onSendMessage,
+  onPerformanceChange,
 }) => {
   return (
     <>
@@ -118,10 +120,10 @@ const SoloHUD: React.FC<SoloHUDProps> = ({
                 notification.type === "success"
                   ? "rgba(0, 200, 0, 0.9)"
                   : notification.type === "warning"
-                  ? "rgba(255, 165, 0, 0.9)"
-                  : notification.type === "error"
-                  ? "rgba(200, 0, 0, 0.9)"
-                  : "rgba(74, 144, 226, 0.9)",
+                    ? "rgba(255, 165, 0, 0.9)"
+                    : notification.type === "error"
+                      ? "rgba(200, 0, 0, 0.9)"
+                      : "rgba(74, 144, 226, 0.9)",
               color: "white",
               borderRadius: "6px",
               fontFamily: "monospace",
@@ -139,7 +141,7 @@ const SoloHUD: React.FC<SoloHUDProps> = ({
       </div>
 
       {/* Performance Monitor */}
-      <PerformanceMonitor onPerformanceChange={() => {}} />
+      <PerformanceMonitor onPerformanceChange={onPerformanceChange} />
 
       {/* Utility Menu (Mute, Quality Settings, Chat) */}
       <UtilityMenu

--- a/src/pages/Solo/components/__tests__/Bots.test.tsx
+++ b/src/pages/Solo/components/__tests__/Bots.test.tsx
@@ -2,6 +2,14 @@ import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import Bots from "../Bots";
+import GameManager, { type Player } from "../../../../components/GameManager";
+
+const makeBotPlayer = (id: string, name: string): Player => ({
+  id,
+  name,
+  position: [0, 0, 0],
+  rotation: [0, 0, 0],
+});
 
 const botPropsByRender: Array<Record<string, unknown>> = [];
 
@@ -138,6 +146,47 @@ describe("Bots", () => {
     expect(setBot2GotTagged).toHaveBeenCalledWith(1234);
 
     nowSpy.mockRestore();
+  });
+
+  it("blocks an immediate IT ping-pong when bot-2 tries to tag bot-1 right back", () => {
+    vi.spyOn(Date, "now").mockReturnValue(5000);
+    vi.spyOn(Math, "random").mockReturnValue(0); // bot-1 becomes IT
+
+    const gm = new GameManager();
+    gm.addPlayer(makeBotPlayer("bot-1", "Bot1"));
+    gm.addPlayer(makeBotPlayer("bot-2", "Bot2"));
+    gm.addPlayer(makeBotPlayer("player-1", "Player1"));
+    gm.startTagGame(60);
+
+    const tagPlayerSpy = vi.spyOn(gm, "tagPlayer");
+
+    const props = buildProps({
+      botDebugMode: true,
+      gameManager: gm as unknown as React.ComponentProps<
+        typeof Bots
+      >["gameManager"],
+      gameState: gm.getGameState(),
+    });
+
+    const { rerender } = render(<Bots {...props} />);
+
+    // Bot-1 (IT) tags bot-2 - bot-2 becomes the new IT.
+    fireEvent.click(screen.getByTestId("bot-1"));
+    expect(gm.getPlayers().get("bot-2")?.isIt).toBe(true);
+    expect(gm.getPlayers().get("bot-1")?.isIt).toBe(false);
+
+    // Re-render so bot1IsIt/bot2IsIt are recomputed from the mutated GameManager.
+    rerender(<Bots {...props} />);
+
+    // Bot-2 (freshly IT) immediately tries to tag bot-1 back.
+    fireEvent.click(screen.getByTestId("bot-4"));
+
+    expect(tagPlayerSpy).toHaveBeenCalledTimes(2);
+    expect(tagPlayerSpy).toHaveLastReturnedWith(false);
+
+    // Only one IT transfer occurred - no ping-pong back to bot-1.
+    expect(gm.getPlayers().get("bot-2")?.isIt).toBe(true);
+    expect(gm.getPlayers().get("bot-1")?.isIt).toBe(false);
   });
 
   it("allows bot-2 to tag bot-1 when bot-2 is IT", () => {

--- a/src/pages/Solo/components/__tests__/SoloHUD.test.tsx
+++ b/src/pages/Solo/components/__tests__/SoloHUD.test.tsx
@@ -99,6 +99,7 @@ const baseProps: React.ComponentProps<typeof SoloHUD> = {
   setChatVisible: vi.fn(),
   chatMessages: [],
   onSendMessage: vi.fn(),
+  onPerformanceChange: vi.fn(),
 };
 
 describe("SoloHUD", () => {


### PR DESCRIPTION
## Summary
- Fix `GameManager.tagPlayer`'s tag-back cooldown: a blanket `lastTagTime` check previously froze a freshly-tagged IT player from tagging *anyone* for 2s. Replaced with a scoped `lastTaggedById`-based check (`TAG_BACK_COOLDOWN_MS`) that only blocks immediately re-tagging your own tagger, while `TAG_FREEZE_MS` still protects a just-tagged player from anyone.
- Fix `useBotAI`'s tag-attempt gate: bots used a 2000ms local retry gate that compounded stalls when `tagPlayer` rejected a tag; replaced with a 200ms `TAG_RETRY_INTERVAL_MS` retry loop, leaving `GameManager` as the single source of truth for cooldown enforcement.
- Add regression coverage: new `src/__tests__/gameManager.edgeCases.test.ts` (8 tests: tag-back cooldown, freeze windows, self-tag rejection, score floor, restart/reset, last-player-removed), 3 new `useBotAI.unit.test.tsx` tests, and a new `Bots.test.tsx` case covering the IT ping-pong race.
- Clean up `Bots.tsx` debug logging via `createTagLogger`, and gate remaining ungated `console.*` calls in `SoundManager.ts`, `UtilityMenu.tsx`, `ControlPanel.tsx`, `ErrorBoundary.tsx`.
- Update `TASKS.md` (move 3 stabilization P0s to Done with evidence; add Phase A-E + server-tag-parity backlog items) and add `docs/MULTIPLAYER_SHOOTER_ROADMAP.md`, anchoring `docs/CONKER_BFD_BUILD_GUIDE.md` to concrete next steps for this codebase (pluggable game modes -> combat primitives -> deathmatch -> CTF -> polish), plus a documented server-side tag parity gap in `server/index.js`.
- Fix `.husky/pre-commit` to detect git worktrees (`.git` is a file) and run `lint-staged` on the host in that case, since Docker can't resolve a worktree's external `.git` pointer.

## Test plan
- [x] `docker compose -f config/docker-compose.yml --project-name darkmoon --profile test run --rm test` -> 378 passed / 5 skipped (ran via pre-push hook)
- [x] Lint (`--max-warnings=0`) clean
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)