### PR TITLE
Add visible laser-fire mechanic to Solo mode (Phase B vertical slice)

### DIFF
--- a/src/components/SoundManager.ts
+++ b/src/components/SoundManager.ts
@@ -239,6 +239,36 @@ class SoundManager {
   }
 
   /**
+   * Play weapon fire sound (laser blaster discharge)
+   */
+  public playWeaponFireSound() {
+    const ctx = this.getAudioContext();
+    const sfxGain = this.getSfxGain();
+    if (!ctx || !sfxGain || this.isMuted) return;
+    try {
+      this.resumeAudioContext();
+      soundEffects.playWeaponFireSoundImpl(ctx, sfxGain, this.sfxVolume);
+    } catch {
+      // ignore
+    }
+  }
+
+  /**
+   * Play hit sound (projectile lands on a target)
+   */
+  public playHitSound() {
+    const ctx = this.getAudioContext();
+    const sfxGain = this.getSfxGain();
+    if (!ctx || !sfxGain || this.isMuted) return;
+    try {
+      this.resumeAudioContext();
+      soundEffects.playHitSoundImpl(ctx, sfxGain, this.sfxVolume);
+    } catch {
+      // ignore
+    }
+  }
+
+  /**
    * Play jetpack activation sound (double-jump trigger)
    */
   public playJetpackActivateSound() {

--- a/src/components/__tests__/soundEffects.test.ts
+++ b/src/components/__tests__/soundEffects.test.ts
@@ -7,6 +7,8 @@ import {
   playTagSoundImpl,
   playTaggedSoundImpl,
   playWalkSoundImpl,
+  playWeaponFireSoundImpl,
+  playHitSoundImpl,
   stopJetpackThrustSoundImpl,
 } from "../soundEffects";
 
@@ -91,6 +93,16 @@ describe("soundEffects", () => {
       0.7,
     );
     playTaggedSoundImpl(
+      ctx as unknown as AudioContext,
+      sfxGain as unknown as GainNode,
+      0.7,
+    );
+    playWeaponFireSoundImpl(
+      ctx as unknown as AudioContext,
+      sfxGain as unknown as GainNode,
+      0.7,
+    );
+    playHitSoundImpl(
       ctx as unknown as AudioContext,
       sfxGain as unknown as GainNode,
       0.7,

--- a/src/components/characters/PlayerCharacter.tsx
+++ b/src/components/characters/PlayerCharacter.tsx
@@ -8,6 +8,8 @@ import GameManager, { GameState } from "../GameManager";
 import { W, A, S, D, Q, E, SHIFT, SPACE } from "../utils";
 import SpacemanModel from "../SpacemanModel";
 import { getSoundManager } from "../SoundManager";
+import { WeaponManager } from "../combat/WeaponManager";
+import { processFiring } from "../../lib/hooks/usePlayerWeapon";
 import { createTagLogger } from "../../lib/utils/logger";
 import {
   usePlayerPhysics,
@@ -31,6 +33,9 @@ import {
 } from "../../lib/hooks/useJetpack";
 
 const tagDebug = createTagLogger("PlayerCharacter");
+
+// How long a fired laser beam stays visible before fading out.
+const LASER_BEAM_VISIBLE_MS = 100;
 
 type WindowWithPlayerFreeze = typeof globalThis & {
   __playerFreezeUntil?: number;
@@ -145,6 +150,14 @@ export const PlayerCharacter = React.forwardRef<
   const [showDustEffect, setShowDustEffect] = useState(false);
   const [showJetpackFlame, setShowJetpackFlame] = useState(false);
   const lookIndicatorRef = React.useRef<THREE.Group>(null);
+  const laserBeamRef = React.useRef<THREE.Group>(null);
+  const laserBeamHideAtRef = React.useRef(0);
+  const weaponManagerRef = React.useRef(new WeaponManager());
+
+  // Equip the laser blaster by default for the visible laser-fire mechanic.
+  React.useEffect(() => {
+    weaponManagerRef.current.equip("laser");
+  }, []);
 
   // Expose reset and freeze functions to parent via ref
   React.useImperativeHandle(ref, () => ({
@@ -362,6 +375,45 @@ export const PlayerCharacter = React.forwardRef<
       } else {
         lookIndicatorRef.current.visible = false;
       }
+    }
+
+    // Fire the equipped laser while left-click is held (rate-limited by
+    // WeaponManager's per-shooter cooldown).
+    if (mouseControls.leftClick && gameManager) {
+      const fireDirection = new THREE.Vector3(
+        -Math.sin(cameraRotationRef.current.horizontal),
+        0,
+        -Math.cos(cameraRotationRef.current.horizontal),
+      );
+      const fireOrigin = meshRef.current.position
+        .clone()
+        .add(new THREE.Vector3(0, 1, 0));
+
+      const fireResult = processFiring({
+        origin: fireOrigin,
+        direction: fireDirection,
+        shooterId: socketClient?.id || currentPlayerId,
+        gameManager,
+        weaponManager: weaponManagerRef.current,
+        collisionSystem: collisionSystemRef.current,
+        now,
+      });
+
+      if (fireResult && laserBeamRef.current) {
+        const beamLength = fireResult.hit?.distance ?? fireResult.weapon.range;
+        laserBeamRef.current.visible = true;
+        laserBeamRef.current.position
+          .copy(fireOrigin)
+          .add(fireDirection.clone().multiplyScalar(beamLength / 2));
+        laserBeamRef.current.rotation.y =
+          cameraRotationRef.current.horizontal + Math.PI;
+        laserBeamRef.current.scale.set(1, 1, beamLength);
+        laserBeamHideAtRef.current = now + LASER_BEAM_VISIBLE_MS;
+      }
+    }
+
+    if (laserBeamRef.current && now >= laserBeamHideAtRef.current) {
+      laserBeamRef.current.visible = false;
     }
 
     // WoW-style auto-run: both mouse buttons held = move forward
@@ -770,55 +822,65 @@ export const PlayerCharacter = React.forwardRef<
 
   // Player spawn at [0, 0.5, 0] - center of map, clear of all rocks
   return (
-    <group ref={meshRef} position={[0, 0.5, 0]}>
-      <SpacemanModel
-        color={isIt ? "#ff4444" : "#4a90e2"}
-        isIt={isIt}
-        velocity={currentVelocity}
-        cameraRotation={currentCameraRotation}
-        isSprinting={isSprinting}
-        isJetpackActive={isJetpackActive}
-      />
-      {/* Jetpack thrust visual effect */}
-      {showJetpackFlame && (
-        <group position={[0, -0.05, 0]}>
-          <mesh rotation={[Math.PI, 0, 0]}>
-            <coneGeometry args={[0.15, 0.4, 8]} />
-            <meshStandardMaterial
-              color="#ff6600"
-              opacity={0.7}
+    <>
+      <group ref={meshRef} position={[0, 0.5, 0]}>
+        <SpacemanModel
+          color={isIt ? "#ff4444" : "#4a90e2"}
+          isIt={isIt}
+          velocity={currentVelocity}
+          cameraRotation={currentCameraRotation}
+          isSprinting={isSprinting}
+          isJetpackActive={isJetpackActive}
+        />
+        {/* Jetpack thrust visual effect */}
+        {showJetpackFlame && (
+          <group position={[0, -0.05, 0]}>
+            <mesh rotation={[Math.PI, 0, 0]}>
+              <coneGeometry args={[0.15, 0.4, 8]} />
+              <meshStandardMaterial
+                color="#ff6600"
+                opacity={0.7}
+                transparent
+                emissive="#ff4400"
+                emissiveIntensity={1.5}
+              />
+            </mesh>
+            <mesh position={[0, 0.1, 0]} rotation={[Math.PI, 0, 0]}>
+              <coneGeometry args={[0.08, 0.25, 8]} />
+              <meshStandardMaterial
+                color="#ffff00"
+                opacity={0.9}
+                transparent
+                emissive="#ffff00"
+                emissiveIntensity={2}
+              />
+            </mesh>
+          </group>
+        )}
+        {/* Landing dust effect */}
+        {showDustEffect && <group position={[0, 0.05, 0]}>{dustMeshes}</group>}
+        {/* Debug hitbox visualization */}
+        {props.showHitboxes && (
+          <mesh position={[0, 0, 0]}>
+            <sphereGeometry args={[0.5, 16, 16]} />
+            <meshBasicMaterial
+              color="#00ff00"
+              wireframe={true}
+              opacity={0.3}
               transparent
-              emissive="#ff4400"
-              emissiveIntensity={1.5}
             />
           </mesh>
-          <mesh position={[0, 0.1, 0]} rotation={[Math.PI, 0, 0]}>
-            <coneGeometry args={[0.08, 0.25, 8]} />
-            <meshStandardMaterial
-              color="#ffff00"
-              opacity={0.9}
-              transparent
-              emissive="#ffff00"
-              emissiveIntensity={2}
-            />
-          </mesh>
-        </group>
-      )}
-      {/* Landing dust effect */}
-      {showDustEffect && <group position={[0, 0.05, 0]}>{dustMeshes}</group>}
-      {/* Debug hitbox visualization */}
-      {props.showHitboxes && (
-        <mesh position={[0, 0, 0]}>
-          <sphereGeometry args={[0.5, 16, 16]} />
-          <meshBasicMaterial
-            color="#00ff00"
-            wireframe={true}
-            opacity={0.3}
-            transparent
-          />
+        )}
+      </group>
+      {/* Laser beam visual: a short-lived stretched box from the shooter
+          toward the hit point (or weapon range on a miss). */}
+      <group ref={laserBeamRef} visible={false}>
+        <mesh>
+          <boxGeometry args={[0.04, 0.04, 1]} />
+          <meshBasicMaterial color="#33ffe6" transparent opacity={0.85} />
         </mesh>
-      )}
-    </group>
+      </group>
+    </>
   );
   /* eslint-enable react/no-unknown-property */
 });

--- a/src/components/soundEffects.ts
+++ b/src/components/soundEffects.ts
@@ -3,13 +3,13 @@ import { createOscillatorWithGain } from "./soundNodeFactory";
 export function playWalkSoundImpl(
   ctx: AudioContext,
   sfxGain: GainNode,
-  sfxVolume: number
+  sfxVolume: number,
 ) {
   try {
     const { osc, gain } = createOscillatorWithGain(
       ctx,
       "sine",
-      80 + Math.random() * 20
+      80 + Math.random() * 20,
     );
 
     gain.gain.value = 0;
@@ -29,7 +29,7 @@ export function playWalkSoundImpl(
 export function playJumpSoundImpl(
   ctx: AudioContext,
   sfxGain: GainNode,
-  sfxVolume: number
+  sfxVolume: number,
 ) {
   try {
     const { osc, gain } = createOscillatorWithGain(ctx, "square", 200);
@@ -53,7 +53,7 @@ export function playJumpSoundImpl(
 export function playLandSoundImpl(
   ctx: AudioContext,
   sfxGain: GainNode,
-  sfxVolume: number
+  sfxVolume: number,
 ) {
   try {
     const { osc, gain } = createOscillatorWithGain(ctx, "sine", 150);
@@ -77,7 +77,7 @@ export function playLandSoundImpl(
 export function playTagSoundImpl(
   ctx: AudioContext,
   sfxGain: GainNode,
-  sfxVolume: number
+  sfxVolume: number,
 ) {
   try {
     const { osc, gain } = createOscillatorWithGain(ctx, "sawtooth", 440);
@@ -102,7 +102,7 @@ export function playTagSoundImpl(
 export function playTaggedSoundImpl(
   ctx: AudioContext,
   sfxGain: GainNode,
-  sfxVolume: number
+  sfxVolume: number,
 ) {
   try {
     const { osc, gain } = createOscillatorWithGain(ctx, "square", 440);
@@ -123,10 +123,58 @@ export function playTaggedSoundImpl(
   }
 }
 
+export function playWeaponFireSoundImpl(
+  ctx: AudioContext,
+  sfxGain: GainNode,
+  sfxVolume: number,
+) {
+  try {
+    const { osc, gain } = createOscillatorWithGain(ctx, "sawtooth", 880);
+    osc.frequency.setValueAtTime(880, ctx.currentTime);
+    osc.frequency.exponentialRampToValueAtTime(220, ctx.currentTime + 0.08);
+
+    gain.gain.value = 0;
+    gain.gain.linearRampToValueAtTime(sfxVolume * 0.5, ctx.currentTime + 0.005);
+    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.12);
+
+    osc.connect(gain);
+    gain.connect(sfxGain);
+
+    osc.start(ctx.currentTime);
+    osc.stop(ctx.currentTime + 0.12);
+  } catch {
+    // ignore
+  }
+}
+
+export function playHitSoundImpl(
+  ctx: AudioContext,
+  sfxGain: GainNode,
+  sfxVolume: number,
+) {
+  try {
+    const { osc, gain } = createOscillatorWithGain(ctx, "square", 180);
+    osc.frequency.setValueAtTime(180, ctx.currentTime);
+    osc.frequency.exponentialRampToValueAtTime(60, ctx.currentTime + 0.1);
+
+    gain.gain.value = 0;
+    gain.gain.linearRampToValueAtTime(sfxVolume * 0.6, ctx.currentTime + 0.01);
+    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.15);
+
+    osc.connect(gain);
+    gain.connect(sfxGain);
+
+    osc.start(ctx.currentTime);
+    osc.stop(ctx.currentTime + 0.15);
+  } catch {
+    // ignore
+  }
+}
+
 export function playJetpackActivateSoundImpl(
   ctx: AudioContext,
   sfxGain: GainNode,
-  sfxVolume: number
+  sfxVolume: number,
 ) {
   try {
     const { osc, gain } = createOscillatorWithGain(ctx, "sawtooth", 100);
@@ -158,7 +206,7 @@ export function playJetpackActivateSoundImpl(
 export function playJetpackThrustSoundImpl(
   ctx: AudioContext,
   sfxGain: GainNode,
-  sfxVolume: number
+  sfxVolume: number,
 ) {
   try {
     const { osc, gain } = createOscillatorWithGain(ctx, "sawtooth", 80);
@@ -187,7 +235,7 @@ export function playJetpackThrustSoundImpl(
 
 export function stopJetpackThrustSoundImpl(
   thrustSound: { osc: OscillatorNode; gain: GainNode } | null,
-  ctx: AudioContext | null
+  ctx: AudioContext | null,
 ) {
   if (!thrustSound || !ctx) return;
   try {

--- a/src/lib/hooks/__tests__/usePlayerWeapon.test.ts
+++ b/src/lib/hooks/__tests__/usePlayerWeapon.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as THREE from "three";
+import { processFiring } from "../usePlayerWeapon";
+import GameManager from "../../../components/GameManager";
+import { CollisionSystem } from "../../../components/CollisionSystem";
+import { WeaponManager } from "../../../components/combat/WeaponManager";
+
+const playWeaponFireSound = vi.fn();
+const playHitSound = vi.fn();
+
+vi.mock("../../../components/SoundManager", () => ({
+  getSoundManager: () => ({
+    playWeaponFireSound,
+    playHitSound,
+  }),
+}));
+
+describe("usePlayerWeapon.processFiring", () => {
+  let gameManager: GameManager;
+  let collisionSystem: CollisionSystem;
+  let weaponManager: WeaponManager;
+  const origin = new THREE.Vector3(0, 0, 0);
+  const direction = new THREE.Vector3(0, 0, -1);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    gameManager = new GameManager();
+    collisionSystem = new CollisionSystem();
+    weaponManager = new WeaponManager();
+
+    gameManager.addPlayer({
+      id: "shooter",
+      name: "Shooter",
+      position: [0, 0, 0],
+      rotation: [0, 0, 0],
+    });
+    gameManager.addPlayer({
+      id: "target",
+      name: "Target",
+      position: [0, 0, -5],
+      rotation: [0, 0, 0],
+    });
+  });
+
+  it("returns null when gameManager is null", () => {
+    weaponManager.equip("laser");
+
+    const result = processFiring({
+      origin,
+      direction,
+      shooterId: "shooter",
+      gameManager: null,
+      weaponManager,
+      collisionSystem,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no weapon is equipped", () => {
+    const result = processFiring({
+      origin,
+      direction,
+      shooterId: "shooter",
+      gameManager,
+      weaponManager,
+      collisionSystem,
+    });
+
+    expect(result).toBeNull();
+    expect(playWeaponFireSound).not.toHaveBeenCalled();
+  });
+
+  it("fires and reports a miss when nothing is in range", () => {
+    weaponManager.equip("laser");
+
+    const result = processFiring({
+      origin,
+      direction: new THREE.Vector3(1, 0, 0), // points away from "target"
+      shooterId: "shooter",
+      gameManager,
+      weaponManager,
+      collisionSystem,
+      now: 1000,
+    });
+
+    expect(result?.hit).toBeNull();
+    expect(playWeaponFireSound).toHaveBeenCalled();
+    expect(playHitSound).not.toHaveBeenCalled();
+    expect(gameManager.getPlayers().get("target")?.health).toBeUndefined();
+  });
+
+  it("fires, hits a target, and applies damage", () => {
+    weaponManager.equip("laser");
+
+    const result = processFiring({
+      origin,
+      direction,
+      shooterId: "shooter",
+      gameManager,
+      weaponManager,
+      collisionSystem,
+      now: 1000,
+    });
+
+    expect(result?.hit?.hitPlayerId).toBe("target");
+    expect(playWeaponFireSound).toHaveBeenCalled();
+    expect(playHitSound).toHaveBeenCalled();
+
+    const target = gameManager.getPlayers().get("target");
+    expect(target?.maxHealth).toBe(100);
+    expect(target?.health).toBe(90);
+  });
+
+  it("clamps health at 0 instead of going negative", () => {
+    weaponManager.equip("laser");
+    gameManager.updatePlayer("target", { health: 5, maxHealth: 100 });
+
+    const result = processFiring({
+      origin,
+      direction,
+      shooterId: "shooter",
+      gameManager,
+      weaponManager,
+      collisionSystem,
+      now: 1000,
+    });
+
+    expect(result?.hit?.hitPlayerId).toBe("target");
+    expect(gameManager.getPlayers().get("target")?.health).toBe(0);
+  });
+
+  it("enforces the weapon cooldown across repeated calls", () => {
+    weaponManager.equip("laser");
+
+    const first = processFiring({
+      origin,
+      direction,
+      shooterId: "shooter",
+      gameManager,
+      weaponManager,
+      collisionSystem,
+      now: 1000,
+    });
+    expect(first).not.toBeNull();
+
+    // Still within the laser's 500ms cooldown - no shot fired.
+    const second = processFiring({
+      origin,
+      direction,
+      shooterId: "shooter",
+      gameManager,
+      weaponManager,
+      collisionSystem,
+      now: 1200,
+    });
+    expect(second).toBeNull();
+
+    // Cooldown has elapsed - shot fires again.
+    const third = processFiring({
+      origin,
+      direction,
+      shooterId: "shooter",
+      gameManager,
+      weaponManager,
+      collisionSystem,
+      now: 1600,
+    });
+    expect(third).not.toBeNull();
+  });
+});

--- a/src/lib/hooks/usePlayerWeapon.ts
+++ b/src/lib/hooks/usePlayerWeapon.ts
@@ -1,0 +1,95 @@
+import * as THREE from "three";
+import type GameManager from "../../components/GameManager";
+import type {
+  CollisionSystem,
+  ProjectileHit,
+} from "../../components/CollisionSystem";
+import type {
+  WeaponConfig,
+  WeaponManager,
+} from "../../components/combat/WeaponManager";
+import { getSoundManager } from "../../components/SoundManager";
+
+const DEFAULT_MAX_HEALTH = 100;
+
+export interface FireParams {
+  origin: THREE.Vector3;
+  direction: THREE.Vector3;
+  shooterId: string;
+  gameManager: GameManager | null;
+  weaponManager: WeaponManager;
+  collisionSystem: CollisionSystem;
+  now?: number;
+}
+
+export interface FireResult {
+  weapon: WeaponConfig;
+  hit: ProjectileHit | null;
+}
+
+/**
+ * Attempt to fire the shooter's equipped weapon along `direction` from
+ * `origin`. Returns null if no shot was fired (no weapon equipped, or the
+ * shooter is still on cooldown). On a hit, applies the weapon's damage to
+ * the target's health via GameManager and plays fire/hit SFX.
+ */
+export function processFiring(params: FireParams): FireResult | null {
+  const {
+    origin,
+    direction,
+    shooterId,
+    gameManager,
+    weaponManager,
+    collisionSystem,
+    now = Date.now(),
+  } = params;
+
+  if (!gameManager) return null;
+
+  const weapon = weaponManager.fire(shooterId, now);
+  if (!weapon) return null;
+
+  const hit = collisionSystem.checkProjectileHit(
+    origin,
+    direction,
+    weapon.range,
+    gameManager.getPlayers(),
+    shooterId,
+  );
+
+  try {
+    const soundMgr = getSoundManager();
+    if (soundMgr) soundMgr.playWeaponFireSound();
+  } catch (e) {
+    if (import.meta.env.DEV) {
+      console.warn("Failed to play weapon fire sound:", e);
+    }
+  }
+
+  if (hit) {
+    const target = gameManager.getPlayers().get(hit.hitPlayerId);
+    if (target) {
+      const maxHealth = target.maxHealth ?? DEFAULT_MAX_HEALTH;
+      const currentHealth = target.health ?? maxHealth;
+      gameManager.updatePlayer(hit.hitPlayerId, {
+        maxHealth,
+        health: Math.max(0, currentHealth - weapon.damage),
+      });
+    }
+
+    try {
+      const soundMgr = getSoundManager();
+      if (soundMgr) soundMgr.playHitSound();
+    } catch (e) {
+      if (import.meta.env.DEV) {
+        console.warn("Failed to play hit sound:", e);
+      }
+    }
+  }
+
+  return { weapon, hit };
+}
+
+export default function usePlayerWeapon() {
+  return { processFiring };
+}


### PR DESCRIPTION
## Summary
- Wires `WeaponManager` (laser equipped by default) + `CollisionSystem.checkProjectileHit` into `PlayerCharacter`: holding left-click fires the equipped laser, rate-limited by its cooldown.
- Renders a brief glowing beam toward the hit point (or weapon range on a miss).
- Applies the weapon's damage to a hit target's `health` (lazily initializing `health`/`maxHealth=100`, clamped at 0).
- Adds `playWeaponFireSound`/`playHitSound` SFX following the existing tag/tagged sound pattern.

This is the "Remaining — vertical slice" item from `docs/MULTIPLAYER_SHOOTER_ROADMAP.md`'s Phase B section, continuing the iteration toward a Conker's Bad Fur Day-style CTF/combat prototype.

## Test plan
- [x] `usePlayerWeapon.test.ts` (6 new tests covering fire/miss/hit/damage clamp/cooldown)
- [x] `soundEffects.test.ts` updated to cover new SFX impls
- [x] Full suite: 397 passed / 5 skipped across 65 files
- [x] Lint (`--max-warnings=0`) and `tsc --noEmit` clean
- [x] Live-checked in browser: firing produces no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)