### PR TITLE
Fix character facing direction so jetpack stays on the back

### DIFF
--- a/src/lib/hooks/__tests__/usePlayerMovement.test.ts
+++ b/src/lib/hooks/__tests__/usePlayerMovement.test.ts
@@ -38,7 +38,7 @@ describe("usePlayerMovement helpers", () => {
       cam,
       { x: 0, y: 0 },
       { W: false, S: false, Q: false, E: false },
-      true
+      true,
     );
     expect(dir.length()).toBeGreaterThan(0);
   });
@@ -52,7 +52,7 @@ describe("usePlayerMovement helpers", () => {
   test("computeFacingYaw follows movement direction when not aiming", () => {
     const direction = new THREE.Vector3(1, 0, 0);
     const facing = computeFacingYaw(direction, 0, false, 0);
-    expect(facing).toBeCloseTo(Math.PI / 2);
+    expect(facing).toBeCloseTo(-Math.PI / 2);
   });
 
   test("computeFacingYaw keeps current yaw with no movement", () => {

--- a/src/lib/hooks/usePlayerMovement.ts
+++ b/src/lib/hooks/usePlayerMovement.ts
@@ -18,19 +18,19 @@ export function computeDirection(
   cameraHorizontal: number,
   joystick: JoystickInput,
   keysPressed: KeysMap,
-  bothMouseButtons: boolean
+  bothMouseButtons: boolean,
 ): THREE.Vector3 {
   const direction = new THREE.Vector3(0, 0, 0);
 
   const forward = new THREE.Vector3(
     -Math.sin(cameraHorizontal),
     0,
-    -Math.cos(cameraHorizontal)
+    -Math.cos(cameraHorizontal),
   );
   const right = new THREE.Vector3(
     Math.cos(cameraHorizontal),
     0,
-    -Math.sin(cameraHorizontal)
+    -Math.sin(cameraHorizontal),
   );
 
   if (bothMouseButtons) {
@@ -72,14 +72,19 @@ export function computeFacingYaw(
   movementDirection: THREE.Vector3,
   cameraHorizontal: number,
   isAiming: boolean,
-  currentYaw: number
+  currentYaw: number,
 ): number {
   if (isAiming) {
     return cameraHorizontal;
   }
 
   if (movementDirection.lengthSq() > 0.0001) {
-    return Math.atan2(movementDirection.x, movementDirection.z);
+    // Negate both components so the result matches the `isAiming` branch's
+    // convention: the model's front (chest) faces `movementDirection`, and
+    // the jetpack on its back ends up on the opposite side. Without the
+    // negation this yaw is offset by PI from the aiming branch, which makes
+    // the character appear to walk backwards with the jetpack facing front.
+    return Math.atan2(-movementDirection.x, -movementDirection.z);
   }
 
   return currentYaw;


### PR DESCRIPTION
## Summary
- The user reported the player character sometimes faces the wrong way, with the jetpack appearing in front instead of behind.
- Root cause: `computeFacingYaw`'s movement branch (`atan2(dir.x, dir.z)`) returned a yaw that's offset by PI relative to its `isAiming` branch (`cameraHorizontal`), for the same direction of travel. Since `isAiming` (right-click) was correct, normal walking was rotated 180° from that convention - putting the back-mounted jetpack in front.
- Fix: negate both `atan2` components in the movement branch so it shares the same facing convention as the aiming branch - the model's front always faces the direction of travel, and the jetpack stays on the back.

## Test plan
- [x] Updated `usePlayerMovement.test.ts` expectation for "computeFacingYaw follows movement direction when not aiming" to match the corrected convention.
- [x] Full Docker test suite green: 397 passed, 5 skipped (65 files).
- [x] Lint (`--max-warnings=0`) and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)