### PR TITLE
Phase C: DeathmatchMode game handler (kills, health, respawn)

### DIFF
--- a/src/__tests__/gameManager.deathmatch.test.ts
+++ b/src/__tests__/gameManager.deathmatch.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import GameManager, { type Player } from "../components/GameManager";
+
+const makePlayer = (id: string, name: string): Player => ({
+  id,
+  name,
+  position: [0, 0, 0],
+  rotation: [0, 0, 0],
+});
+
+describe("GameManager deathmatch", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starting deathmatch initializes health, maxHealth, and scores for all players", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+
+    expect(manager.startDeathmatchGame(120, 5)).toBe(true);
+
+    const state = manager.getGameState();
+    expect(state.mode).toBe("deathmatch");
+    expect(state.isActive).toBe(true);
+    expect(state.killLimit).toBe(5);
+
+    for (const player of manager.getPlayers().values()) {
+      expect(player.health).toBe(100);
+      expect(player.maxHealth).toBe(100);
+      expect(state.scores[player.id]).toBe(0);
+    }
+  });
+
+  it("a hit reduces the target's health", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+    manager.startDeathmatchGame();
+
+    expect(manager.hitPlayer("p1", "p2", 30)).toBe(true);
+    expect(manager.getPlayers().get("p2")?.health).toBe(70);
+  });
+
+  it("a lethal hit awards the attacker a kill and starts the target's respawn timer", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+
+    vi.spyOn(Date, "now").mockReturnValue(10000);
+    manager.startDeathmatchGame();
+
+    expect(manager.hitPlayer("p1", "p2", 150)).toBe(true);
+
+    const target = manager.getPlayers().get("p2")!;
+    expect(target.health).toBe(0);
+    expect(target.respawnAt).toBe(13000);
+    expect(manager.getGameState().scores["p1"]).toBe(1);
+  });
+
+  it("restores health and clears respawnAt once the respawn delay elapses", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+
+    vi.spyOn(Date, "now").mockReturnValue(10000);
+    manager.startDeathmatchGame();
+    manager.hitPlayer("p1", "p2", 1000);
+
+    const target = manager.getPlayers().get("p2")!;
+    expect(target.health).toBe(0);
+    expect(target.respawnAt).toBe(13000);
+
+    vi.spyOn(Date, "now").mockReturnValue(13001);
+    manager.updateGameTimer(0.1);
+
+    expect(target.health).toBe(target.maxHealth);
+    expect(target.respawnAt).toBeUndefined();
+  });
+
+  it("rejects self-hits", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.startDeathmatchGame();
+
+    expect(manager.hitPlayer("p1", "p1", 10)).toBe(false);
+  });
+
+  it("rejects hits outside an active deathmatch", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+
+    // Not started yet
+    expect(manager.hitPlayer("p1", "p2", 10)).toBe(false);
+
+    // Started in tag mode instead
+    manager.startTagGame();
+    expect(manager.hitPlayer("p1", "p2", 10)).toBe(false);
+  });
+
+  it("rejects hits on a player who is awaiting respawn", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+
+    vi.spyOn(Date, "now").mockReturnValue(10000);
+    manager.startDeathmatchGame();
+    manager.hitPlayer("p1", "p2", 1000); // p2 downed, awaiting respawn
+
+    expect(manager.hitPlayer("p1", "p2", 10)).toBe(false);
+  });
+
+  it("ends the game once a player reaches the kill limit, with results sorted by kills", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+
+    vi.spyOn(Date, "now").mockReturnValue(10000);
+    manager.startDeathmatchGame(120, 1);
+
+    manager.hitPlayer("p1", "p2", 1000); // p1 reaches the kill limit of 1
+    expect(manager.getGameState().timeRemaining).toBeLessThanOrEqual(0);
+
+    manager.updateGameTimer(0.1);
+    expect(manager.getGameState().isActive).toBe(false);
+
+    const results = manager.endGame();
+    expect(results).toEqual([
+      { id: "p1", name: "P1", score: 1 },
+      { id: "p2", name: "P2", score: 0 },
+    ]);
+  });
+});

--- a/src/components/GameManager.ts
+++ b/src/components/GameManager.ts
@@ -1,10 +1,17 @@
 import { createLogger } from "../lib/utils/logger";
 import type { GameModeHandler } from "./gameModes/GameModeHandler";
 import TagMode from "./gameModes/TagMode";
+import DeathmatchMode from "./gameModes/DeathmatchMode";
 
 const log = createLogger("GameManager");
 
-export type GameMode = "none" | "tag" | "collectible" | "race" | "solo";
+export type GameMode =
+  | "none"
+  | "tag"
+  | "deathmatch"
+  | "collectible"
+  | "race"
+  | "solo";
 
 export interface GameState {
   mode: GameMode;
@@ -13,6 +20,8 @@ export interface GameState {
   scores: { [playerId: string]: number };
   itPlayerId?: string; // For tag mode
   roundStartTime?: number;
+  /** Kills required to win deathmatch. */
+  killLimit?: number;
 }
 
 export interface TagGameState extends GameState {
@@ -47,9 +56,9 @@ export class GameManager {
     onPlayerUpdate?: (players: Map<string, Player>) => void;
   };
 
-  // Active mode rules. Only "tag" is implemented today; future modes
-  // (deathmatch, CTF, ...) will be selected based on gameState.mode.
-  private readonly mode: GameModeHandler;
+  // Active mode rules, swapped out by startTagGame/startDeathmatchGame/...
+  // based on gameState.mode.
+  private mode: GameModeHandler;
 
   constructor() {
     this.gameState = {
@@ -120,6 +129,7 @@ export class GameManager {
       roundStartTime: Date.now(),
     };
 
+    this.mode = new TagMode();
     this.mode.onStart(this.players, this.gameState);
 
     this.callbacks.onGameStateUpdate?.(this.gameState);
@@ -145,6 +155,44 @@ export class GameManager {
 
     const accepted = this.mode.onAction(
       { type: "tag", taggerId, taggedId },
+      this.players,
+      this.gameState,
+    );
+
+    if (accepted) {
+      this.callbacks.onGameStateUpdate?.(this.gameState);
+      this.callbacks.onPlayerUpdate?.(this.players);
+    }
+
+    return accepted;
+  }
+
+  startDeathmatchGame(duration: number = 120, killLimit: number = 10) {
+    this.gameState = {
+      mode: "deathmatch",
+      isActive: true,
+      timeRemaining: duration,
+      scores: {},
+      killLimit,
+      roundStartTime: Date.now(),
+    };
+
+    this.mode = new DeathmatchMode();
+    this.mode.onStart(this.players, this.gameState);
+
+    this.callbacks.onGameStateUpdate?.(this.gameState);
+    this.callbacks.onPlayerUpdate?.(this.players);
+    log.debug(`Deathmatch started! Kill limit: ${killLimit}`);
+    return true;
+  }
+
+  hitPlayer(attackerId: string, targetId: string, damage: number): boolean {
+    if (this.gameState.mode !== "deathmatch" || !this.gameState.isActive) {
+      return false;
+    }
+
+    const accepted = this.mode.onAction(
+      { type: "hit", attackerId, targetId, damage },
       this.players,
       this.gameState,
     );

--- a/src/components/gameModes/DeathmatchMode.ts
+++ b/src/components/gameModes/DeathmatchMode.ts
@@ -1,0 +1,107 @@
+import { createLogger } from "../../lib/utils/logger";
+import type { GameState, Player } from "../GameManager";
+import type {
+  GameAction,
+  GameModeHandler,
+  GameResult,
+} from "./GameModeHandler";
+
+const log = createLogger("DeathmatchMode");
+
+/**
+ * Deathmatch rules: every player starts with full health and damages others
+ * with weapon hits. A lethal hit awards the attacker a kill and puts the
+ * target on a brief respawn timer; reaching killLimit ends the round.
+ */
+export class DeathmatchMode implements GameModeHandler {
+  private readonly DEFAULT_MAX_HEALTH = 100;
+  private readonly RESPAWN_DELAY_MS = 3000;
+
+  onStart(players: Map<string, Player>, gameState: GameState): void {
+    players.forEach((player, id) => {
+      gameState.scores[id] = 0;
+      player.maxHealth = player.maxHealth ?? this.DEFAULT_MAX_HEALTH;
+      player.health = player.maxHealth;
+      player.respawnAt = undefined;
+    });
+  }
+
+  onTick(
+    deltaTime: number,
+    players: Map<string, Player>,
+    gameState: GameState,
+  ): void {
+    gameState.timeRemaining -= deltaTime;
+
+    const now = Date.now();
+    players.forEach((player) => {
+      if (player.respawnAt !== undefined && now >= player.respawnAt) {
+        player.health = player.maxHealth ?? this.DEFAULT_MAX_HEALTH;
+        player.respawnAt = undefined;
+      }
+    });
+  }
+
+  onAction(
+    action: GameAction,
+    players: Map<string, Player>,
+    gameState: GameState,
+  ): boolean {
+    if (action.type !== "hit") return false;
+    const { attackerId, targetId, damage } = action;
+
+    if (attackerId === targetId) return false;
+
+    const attacker = players.get(attackerId);
+    const target = players.get(targetId);
+    if (!attacker || !target) return false;
+
+    // A downed player awaiting respawn can't take further damage.
+    if (target.respawnAt !== undefined) return false;
+
+    const maxHealth = target.maxHealth ?? this.DEFAULT_MAX_HEALTH;
+    const currentHealth = target.health ?? maxHealth;
+    target.health = Math.max(0, currentHealth - damage);
+
+    if (target.health === 0) {
+      gameState.scores[attackerId] = (gameState.scores[attackerId] ?? 0) + 1;
+      target.respawnAt = Date.now() + this.RESPAWN_DELAY_MS;
+
+      log.debug(
+        `${attacker.name} eliminated ${target.name}! (${gameState.scores[attackerId]} kills)`,
+      );
+
+      if (
+        gameState.killLimit !== undefined &&
+        gameState.scores[attackerId] >= gameState.killLimit
+      ) {
+        gameState.timeRemaining = 0;
+      }
+    }
+
+    return true;
+  }
+
+  onPlayerRemoved(): void {
+    // No shared role (e.g. "IT") to reassign when a player leaves.
+  }
+
+  onEnd(players: Map<string, Player>, gameState: GameState): GameResult[] {
+    const results = Array.from(players.entries())
+      .map(([id, player]) => ({
+        id,
+        name: player.name,
+        score: gameState.scores[id] || 0,
+      }))
+      .sort((a, b) => b.score - a.score);
+
+    players.forEach((player) => {
+      player.health = player.maxHealth;
+      player.respawnAt = undefined;
+    });
+
+    return results;
+  }
+}
+
+export default DeathmatchMode;

--- a/src/components/gameModes/GameModeHandler.ts
+++ b/src/components/gameModes/GameModeHandler.ts
@@ -6,11 +6,18 @@ export interface GameResult {
   score: number;
 }
 
-export type GameAction = {
-  type: "tag";
-  taggerId: string;
-  taggedId: string;
-};
+export type GameAction =
+  | {
+      type: "tag";
+      taggerId: string;
+      taggedId: string;
+    }
+  | {
+      type: "hit";
+      attackerId: string;
+      targetId: string;
+      damage: number;
+    };
 
 /**
  * Mode-specific rules for a GameManager-hosted game. GameManager owns the


### PR DESCRIPTION
## Summary

Backend scaffolding for **Phase C (Deathmatch)** per `docs/MULTIPLAYER_SHOOTER_ROADMAP.md`, building on the pluggable game-mode architecture from Phase A and the combat primitives (health/respawn fields) from Phase B.

- **`DeathmatchMode`** implements `GameModeHandler`: players spawn at full health, weapon hits deal damage, a lethal hit awards the attacker a kill (tracked in `gameState.scores`, mirroring how TagMode uses it), and puts the target on a 3s respawn timer via `Player.respawnAt`. Reaching `killLimit` ends the round.
- **`GameAction`** becomes a discriminated union: `{ type: "tag", ... } | { type: "hit", attackerId, targetId, damage }`.
- **`GameManager`** gains `startDeathmatchGame(duration = 120, killLimit = 10)` and `hitPlayer(attackerId, targetId, damage)`; the active mode handler is now swapped per `startXGame()` call instead of being fixed at construction.
- Downed players (awaiting respawn) can't take damage or be re-killed; self-hits are rejected; hits outside an active deathmatch are rejected.

## Tests

8 new regression tests in `src/__tests__/gameManager.deathmatch.test.ts` covering init, damage, lethal hits + kill scoring, respawn timing, self-hit/downed-target/wrong-mode rejection, and kill-limit game end with sorted results.

Full Docker suite: **66 files, 405 passed / 5 skipped** (pre-push hook re-verified).

## Follow-up (next PR)

UI/bot wiring: route `usePlayerWeapon` laser hits through `gameManager.hitPlayer()`, add a "Start Deathmatch" trigger and kills scoreboard in `GameUI.tsx`, make bots damageable targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)