### PR TITLE
Make deathmatch playable in Solo: laser kills, scoreboard, live positions

### DIFF
--- a/src/__tests__/gameManager.core.test.ts
+++ b/src/__tests__/gameManager.core.test.ts
@@ -19,6 +19,21 @@ describe("GameManager core", () => {
     vi.restoreAllMocks();
   });
 
+  it("updatePlayerPosition syncs position without firing update callbacks", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "Player 1"));
+
+    const onPlayerUpdate = vi.fn();
+    manager.setCallbacks({ onPlayerUpdate });
+
+    manager.updatePlayerPosition("p1", [1, 2, 3]);
+    expect(manager.getPlayers().get("p1")?.position).toEqual([1, 2, 3]);
+    expect(onPlayerUpdate).not.toHaveBeenCalled();
+
+    // Unknown player is a safe no-op
+    manager.updatePlayerPosition("ghost", [9, 9, 9]);
+  });
+
   it("blocks tag game start with exactly one player", () => {
     const manager = new GameManager();
     manager.addPlayer(makePlayer("p1", "Player 1"));

--- a/src/components/GameManager.ts
+++ b/src/components/GameManager.ts
@@ -107,6 +107,18 @@ export class GameManager {
     }
   }
 
+  /**
+   * Per-frame position sync that skips update callbacks so 60fps movement
+   * doesn't re-render React consumers. Positions are read on demand
+   * (projectile hit checks, tag distance checks).
+   */
+  updatePlayerPosition(playerId: string, position: [number, number, number]) {
+    const player = this.players.get(playerId);
+    if (player) {
+      player.position = position;
+    }
+  }
+
   startTagGame(duration: number = 60) {
     // 1 minute default for faster playtesting (dynamic: +1min per player above 2)
     // Allow solo practice (0 players) or real games with 2+ players; block single-player

--- a/src/components/GameUI.tsx
+++ b/src/components/GameUI.tsx
@@ -23,7 +23,7 @@ const GameUI: React.FC<GameUIProps> = ({
   // Detect mobile viewport and landscape orientation
   const [isMobile, setIsMobile] = React.useState(window.innerWidth <= 768);
   const [isLandscape, setIsLandscape] = React.useState(
-    window.innerWidth > window.innerHeight
+    window.innerWidth > window.innerHeight,
   );
 
   React.useEffect(() => {
@@ -117,8 +117,8 @@ const GameUI: React.FC<GameUIProps> = ({
                   ? "🏃 IT!"
                   : `${itPlayer?.name?.substring(0, 6) || "?"}`
                 : currentPlayer?.isIt
-                ? "🏃 YOU ARE IT!"
-                : `${itPlayer?.name || "Someone"} is IT`}
+                  ? "🏃 YOU ARE IT!"
+                  : `${itPlayer?.name || "Someone"} is IT`}
             </div>
 
             {currentPlayer?.isIt && !isMobile && !isMinimal && (
@@ -130,6 +130,47 @@ const GameUI: React.FC<GameUIProps> = ({
                 }}
               >
                 Tag someone!
+              </div>
+            )}
+          </>
+        )}
+
+        {gameState.mode === "deathmatch" && (
+          <>
+            <div
+              style={{
+                marginBottom: isMinimal ? "2px" : "6px",
+                padding: isMinimal ? "2px 3px" : "4px 8px",
+                backgroundColor: "rgba(100, 255, 100, 0.2)",
+                borderRadius: "3px",
+                border: "1px solid #64ff64",
+                fontSize: isMinimal ? "8px" : isMobile ? "10px" : "11px",
+              }}
+            >
+              ❤️ {currentPlayer?.health ?? currentPlayer?.maxHealth ?? 100}
+              {!isMinimal && ` / ${currentPlayer?.maxHealth ?? 100}`}
+            </div>
+
+            {!isMinimal && (
+              <div
+                style={{
+                  marginBottom: "6px",
+                  fontSize: isMobile ? "9px" : "10px",
+                  textAlign: "left",
+                }}
+              >
+                {Array.from(players.values())
+                  .map((player) => ({
+                    name: player.name,
+                    kills: gameState.scores[player.id] || 0,
+                  }))
+                  .sort((a, b) => b.kills - a.kills)
+                  .map((entry) => (
+                    <div key={entry.name}>
+                      💀 {entry.name}: {entry.kills}
+                      {gameState.killLimit ? ` / ${gameState.killLimit}` : ""}
+                    </div>
+                  ))}
               </div>
             )}
           </>
@@ -173,8 +214,8 @@ const GameUI: React.FC<GameUIProps> = ({
             {isMinimal || isMobile
               ? "🔧"
               : botDebugMode
-              ? "⏹️ Stop Debug"
-              : "🔧 Debug Mode"}
+                ? "⏹️ Stop Debug"
+                : "🔧 Debug Mode"}
           </button>
         )}
       </div>
@@ -237,8 +278,8 @@ const GameUI: React.FC<GameUIProps> = ({
               padding: isMinimal
                 ? "3px 5px"
                 : isMobile
-                ? "6px 8px"
-                : "6px 10px",
+                  ? "6px 8px"
+                  : "6px 10px",
               backgroundColor: "rgba(74, 144, 226, 0.8)",
               border: "1px solid #4a90e2",
               borderRadius: "3px",
@@ -253,14 +294,36 @@ const GameUI: React.FC<GameUIProps> = ({
               : `Start Tag ${players.size <= 1 ? "(Practice)" : ""}`}
           </button>
 
+          {players.size >= 2 && (
+            <button
+              onClick={() => onStartGame("deathmatch")}
+              style={{
+                padding: isMinimal
+                  ? "3px 5px"
+                  : isMobile
+                    ? "6px 8px"
+                    : "6px 10px",
+                backgroundColor: "rgba(220, 53, 69, 0.8)",
+                border: "1px solid #dc3545",
+                borderRadius: "3px",
+                color: "white",
+                cursor: "pointer",
+                fontSize: isMinimal ? "14px" : isMobile ? "14px" : "11px",
+                width: "100%",
+              }}
+            >
+              {isMinimal || isMobile ? "🔫" : "Start Deathmatch"}
+            </button>
+          )}
+
           <button
             onClick={() => onToggleDebug && onToggleDebug()}
             style={{
               padding: isMinimal
                 ? "3px 5px"
                 : isMobile
-                ? "6px 8px"
-                : "6px 10px",
+                  ? "6px 8px"
+                  : "6px 10px",
               backgroundColor: botDebugMode
                 ? "rgba(220, 53, 69, 0.8)"
                 : "rgba(255, 140, 0, 0.8)",
@@ -275,8 +338,8 @@ const GameUI: React.FC<GameUIProps> = ({
             {isMinimal || isMobile
               ? "🔧"
               : botDebugMode
-              ? "⏹️ Stop Debug"
-              : "🔧 Start Debug"}
+                ? "⏹️ Stop Debug"
+                : "🔧 Start Debug"}
           </button>
 
           {!isMobile && !isMinimal && (

--- a/src/components/__tests__/GameUI.test.tsx
+++ b/src/components/__tests__/GameUI.test.tsx
@@ -86,7 +86,42 @@ describe("GameUI", () => {
     fireEvent.click(screen.getByText("Start Tag"));
     expect(onStartGame).toHaveBeenCalledWith("tag");
 
+    fireEvent.click(screen.getByText("Start Deathmatch"));
+    expect(onStartGame).toHaveBeenCalledWith("deathmatch");
+
     fireEvent.click(screen.getByText("⏹️ Stop Debug"));
     expect(onToggleDebug).toHaveBeenCalled();
+  });
+
+  it("renders health and a kill scoreboard during an active deathmatch", () => {
+    const players = mkPlayers();
+    players.get("p1")!.health = 70;
+    players.get("p1")!.maxHealth = 100;
+    players.get("p2")!.health = 100;
+    players.get("p2")!.maxHealth = 100;
+
+    const gameState: GameState = {
+      mode: "deathmatch",
+      isActive: true,
+      timeRemaining: 90,
+      scores: { p1: 2, p2: 5 },
+      killLimit: 10,
+      roundStartTime: Date.now(),
+    };
+
+    render(
+      <GameUI
+        gameState={gameState}
+        players={players}
+        currentPlayerId="p1"
+        onStartGame={vi.fn()}
+        onEndGame={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/DEATHMATCH GAME/)).toBeInTheDocument();
+    expect(screen.getByText("❤️ 70 / 100")).toBeInTheDocument();
+    expect(screen.getByText("💀 Player Two: 5 / 10")).toBeInTheDocument();
+    expect(screen.getByText("💀 Player One: 2 / 10")).toBeInTheDocument();
   });
 });

--- a/src/lib/hooks/__tests__/usePlayerWeapon.test.ts
+++ b/src/lib/hooks/__tests__/usePlayerWeapon.test.ts
@@ -130,6 +130,52 @@ describe("usePlayerWeapon.processFiring", () => {
     expect(gameManager.getPlayers().get("target")?.health).toBe(0);
   });
 
+  it("routes hits through GameManager.hitPlayer during an active deathmatch", () => {
+    weaponManager.equip("laser");
+    gameManager.startDeathmatchGame(120, 5);
+    // Leave the target one laser hit from elimination.
+    gameManager.updatePlayer("target", { health: 10 });
+
+    const result = processFiring({
+      origin,
+      direction,
+      shooterId: "shooter",
+      gameManager,
+      weaponManager,
+      collisionSystem,
+      now: 1000,
+    });
+
+    expect(result?.hit?.hitPlayerId).toBe("target");
+    const target = gameManager.getPlayers().get("target");
+    expect(target?.health).toBe(0);
+    expect(target?.respawnAt).toBeDefined();
+    expect(gameManager.getGameState().scores["shooter"]).toBe(1);
+    expect(playHitSound).toHaveBeenCalled();
+  });
+
+  it("deals no damage to a downed target awaiting respawn in deathmatch", () => {
+    weaponManager.equip("laser");
+    gameManager.startDeathmatchGame(120, 5);
+    gameManager.hitPlayer("shooter", "target", 1000); // down the target
+
+    const result = processFiring({
+      origin,
+      direction,
+      shooterId: "shooter",
+      gameManager,
+      weaponManager,
+      collisionSystem,
+      now: 1000,
+    });
+
+    // The shot still fires and reports the hit, but no damage or kill credit.
+    expect(result?.hit?.hitPlayerId).toBe("target");
+    expect(gameManager.getPlayers().get("target")?.health).toBe(0);
+    expect(gameManager.getGameState().scores["shooter"]).toBe(1);
+    expect(playHitSound).not.toHaveBeenCalled();
+  });
+
   it("enforces the weapon cooldown across repeated calls", () => {
     weaponManager.equip("laser");
 

--- a/src/lib/hooks/usePlayerWeapon.ts
+++ b/src/lib/hooks/usePlayerWeapon.ts
@@ -67,22 +67,38 @@ export function processFiring(params: FireParams): FireResult | null {
   }
 
   if (hit) {
-    const target = gameManager.getPlayers().get(hit.hitPlayerId);
-    if (target) {
-      const maxHealth = target.maxHealth ?? DEFAULT_MAX_HEALTH;
-      const currentHealth = target.health ?? maxHealth;
-      gameManager.updatePlayer(hit.hitPlayerId, {
-        maxHealth,
-        health: Math.max(0, currentHealth - weapon.damage),
-      });
+    const gameState = gameManager.getGameState();
+    let damageApplied = false;
+
+    if (gameState.mode === "deathmatch" && gameState.isActive) {
+      // Deathmatch: DeathmatchMode applies damage, awards kills, and starts
+      // respawn timers. Rejected hits (e.g. a downed target) deal no damage.
+      damageApplied = gameManager.hitPlayer(
+        shooterId,
+        hit.hitPlayerId,
+        weapon.damage,
+      );
+    } else {
+      const target = gameManager.getPlayers().get(hit.hitPlayerId);
+      if (target) {
+        const maxHealth = target.maxHealth ?? DEFAULT_MAX_HEALTH;
+        const currentHealth = target.health ?? maxHealth;
+        gameManager.updatePlayer(hit.hitPlayerId, {
+          maxHealth,
+          health: Math.max(0, currentHealth - weapon.damage),
+        });
+        damageApplied = true;
+      }
     }
 
-    try {
-      const soundMgr = getSoundManager();
-      if (soundMgr) soundMgr.playHitSound();
-    } catch (e) {
-      if (import.meta.env.DEV) {
-        console.warn("Failed to play hit sound:", e);
+    if (damageApplied) {
+      try {
+        const soundMgr = getSoundManager();
+        if (soundMgr) soundMgr.playHitSound();
+      } catch (e) {
+        if (import.meta.env.DEV) {
+          console.warn("Failed to play hit sound:", e);
+        }
       }
     }
   }

--- a/src/pages/Solo.tsx
+++ b/src/pages/Solo.tsx
@@ -411,12 +411,15 @@ const Solo: React.FC = () => {
     };
   }, [setMouseControls]);
 
-  // Player position tracking - use refs to avoid re-render loops
+  // Player position tracking - use refs to avoid re-render loops. Also sync
+  // into GameManager (callback-free) so projectile hit checks see live
+  // positions.
   const handlePlayerPositionUpdate = useCallback(
     (position: [number, number, number]) => {
       playerPositionRef.current = position;
+      gameManager.current?.updatePlayerPosition(currentPlayerId, position);
     },
-    [],
+    [currentPlayerId],
   );
 
   // Bot position tracking - use refs to avoid re-render loops AND update clients object for collision
@@ -425,6 +428,7 @@ const Solo: React.FC = () => {
       bot1PositionRef.current = position;
       // Update clients ref so PlayerCharacter can detect bot for tagging (no re-render)
       clientsRef.current["bot-1"] = { position, rotation: ZERO_ROTATION };
+      gameManager.current?.updatePlayerPosition("bot-1", position);
     },
     [],
   );
@@ -434,6 +438,7 @@ const Solo: React.FC = () => {
       bot2PositionRef.current = position;
       // Update clients ref so PlayerCharacter can detect bot for tagging (no re-render)
       clientsRef.current["bot-2"] = { position, rotation: ZERO_ROTATION };
+      gameManager.current?.updatePlayerPosition("bot-2", position);
     },
     [],
   );
@@ -540,22 +545,33 @@ const Solo: React.FC = () => {
     });
   };
 
-  const handleStartTagGame = () => {
-    if (gameManager.current) {
-      gameManager.current.startTagGame();
+  const handleStartGame = (mode: string) => {
+    if (!gameManager.current) return;
+
+    if (mode === "deathmatch") {
+      gameManager.current.startDeathmatchGame();
       const newGameState = gameManager.current.getGameState();
       setGameState(newGameState);
+      addNotification(
+        `Deathmatch started! First to ${newGameState.killLimit} kills wins!`,
+        "warning",
+      );
+      return;
+    }
 
-      // Show correct notification based on who is IT
-      const itPlayerId = newGameState.itPlayerId;
+    gameManager.current.startTagGame();
+    const newGameState = gameManager.current.getGameState();
+    setGameState(newGameState);
 
-      if (itPlayerId === currentPlayerId) {
-        addNotification("Tag game started! You're IT!", "warning");
-      } else {
-        const itPlayer = gameManager.current.getPlayers().get(itPlayerId || "");
-        const itName = itPlayer?.name || "Someone";
-        addNotification(`Tag game started! ${itName} is IT!`, "info");
-      }
+    // Show correct notification based on who is IT
+    const itPlayerId = newGameState.itPlayerId;
+
+    if (itPlayerId === currentPlayerId) {
+      addNotification("Tag game started! You're IT!", "warning");
+    } else {
+      const itPlayer = gameManager.current.getPlayers().get(itPlayerId || "");
+      const itName = itPlayer?.name || "Someone";
+      addNotification(`Tag game started! ${itName} is IT!`, "info");
     }
   };
 
@@ -632,7 +648,7 @@ const Solo: React.FC = () => {
         gameState={gameState}
         players={gamePlayers}
         currentPlayerId={currentPlayerId}
-        onStartGame={handleStartTagGame}
+        onStartGame={handleStartGame}
         onEndGame={handleEndGame}
         botDebugMode={botDebugMode}
         onToggleDebug={() => setBotDebugMode((prev) => !prev)}

--- a/src/pages/Solo/components/SoloHUD.tsx
+++ b/src/pages/Solo/components/SoloHUD.tsx
@@ -22,7 +22,7 @@ interface SoloHUDProps {
   gameState: GameState;
   players: Map<string, Player>;
   currentPlayerId: string;
-  onStartGame: () => void;
+  onStartGame: (mode: string) => void;
   onEndGame: () => void;
   botDebugMode: boolean;
   onToggleDebug: () => void;


### PR DESCRIPTION
## Summary

Phase C part 2 — wires the DeathmatchMode backend (#241) into actual Solo gameplay:

- **Laser hits award kills**: `processFiring` now routes hits through `gameManager.hitPlayer()` during an active deathmatch, so DeathmatchMode applies damage, awards kill credit, and starts respawn timers. Downed targets awaiting respawn take no damage and skip the hit sound. All other modes keep the existing direct health-decrement behavior.
- **Start Deathmatch + HUD**: `GameUI` gains a "Start Deathmatch" button in the lobby (2+ players — the solo bot counts) and an in-game deathmatch panel showing current health (❤️ 70 / 100) and a kill scoreboard sorted by kills with the kill limit (💀 Bot: 5 / 10).
- **Mode-aware start handler**: Solo's `handleStartGame(mode)` calls `startDeathmatchGame()` for `"deathmatch"`, with the existing tag flow otherwise.
- **Live position sync**: new `GameManager.updatePlayerPosition()` syncs per-frame player/bot positions without firing React update callbacks (no 60fps re-renders). Previously GameManager positions never updated after spawn, so projectile hit checks only registered at spawn points — this fixes laser hit detection against moving bots.

## Tests

4 new tests: deathmatch hit routing through `hitPlayer` (kill + respawn timer) and downed-target rejection in `usePlayerWeapon.test.ts`; Start Deathmatch button + deathmatch HUD rendering in `GameUI.test.tsx`; callback-free position sync in `gameManager.core.test.ts`.

Full Docker suite: **66 files, 409 passed / 5 skipped** (pre-push hook re-verified).

## Follow-up (next PR)

Bots fighting back: bot AI fires lasers at the nearest target during deathmatch, making it a real firefight per the Conker's BFD roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)