### PR TITLE
Bots fight back in deathmatch: chase to range, fire lasers, sit out when downed

### DIFF
--- a/src/__tests__/useBotAI.unit.test.tsx
+++ b/src/__tests__/useBotAI.unit.test.tsx
@@ -41,9 +41,11 @@ type HarnessProps = {
   isIt: boolean;
   targetIsIt: boolean;
   onTagTarget: () => void;
+  onFireAtTarget?: () => void;
+  isDowned?: boolean;
   onPositionUpdate: (position: [number, number, number]) => void;
   gameState: {
-    mode: "tag" | "none";
+    mode: "tag" | "deathmatch" | "none";
     isActive: boolean;
     timeRemaining: number;
     scores: Record<string, number>;
@@ -70,6 +72,7 @@ function mountHook(overrides?: Partial<HarnessProps>) {
   const meshRef = makeMesh();
   const capturedRef = React.createRef<ReturnType<typeof useBotAI> | null>();
   const onTagTarget = vi.fn();
+  const onFireAtTarget = vi.fn();
   const onPositionUpdate = vi.fn();
 
   const baseProps: HarnessProps = {
@@ -78,6 +81,7 @@ function mountHook(overrides?: Partial<HarnessProps>) {
     isIt: true,
     targetIsIt: false,
     onTagTarget,
+    onFireAtTarget,
     onPositionUpdate,
     gameState: {
       mode: "tag",
@@ -116,9 +120,17 @@ function mountHook(overrides?: Partial<HarnessProps>) {
     refs: capturedRef.current as ReturnType<typeof useBotAI>,
     meshRef,
     onTagTarget,
+    onFireAtTarget,
     onPositionUpdate,
   };
 }
+
+const deathmatchState = {
+  mode: "deathmatch" as const,
+  isActive: true,
+  timeRemaining: 120,
+  scores: {},
+};
 
 describe("useBotAI", () => {
   beforeEach(() => {
@@ -243,6 +255,68 @@ describe("useBotAI", () => {
     nowSpy.mockReturnValue(700);
     frameCallback!(null, 0.016);
     expect(refs.isSprinting.current).toBe(true);
+  });
+
+  it("advances toward the target in deathmatch when beyond fire range", () => {
+    vi.spyOn(Date, "now").mockReturnValue(5000);
+
+    const { meshRef, onFireAtTarget } = mountHook({
+      isIt: false,
+      targetIsIt: false,
+      gameState: deathmatchState,
+      targetPositionRef: { current: [20, 0, 0] },
+    });
+
+    frameCallback!(null, 1);
+
+    expect(meshRef.current.position.x).toBeGreaterThan(0);
+    expect(onFireAtTarget).not.toHaveBeenCalled();
+  });
+
+  it("holds position and fires on a retry interval when within fire range", () => {
+    const nowSpy = vi.spyOn(Date, "now");
+    nowSpy.mockReturnValue(5000);
+
+    const { meshRef, onFireAtTarget } = mountHook({
+      isIt: false,
+      targetIsIt: false,
+      gameState: deathmatchState,
+      targetPositionRef: { current: [5, 0, 0] }, // within FIRE_RANGE (10)
+    });
+
+    frameCallback!(null, 0.016);
+    expect(meshRef.current.position.x).toBe(0);
+    expect(onFireAtTarget).toHaveBeenCalledTimes(1);
+
+    // Same instant - the bot shouldn't spam fire attempts every frame; the
+    // parent's WeaponManager owns the real cooldown.
+    frameCallback!(null, 0.016);
+    expect(onFireAtTarget).toHaveBeenCalledTimes(1);
+
+    // Once the retry interval (200ms) elapses, the bot tries again.
+    nowSpy.mockReturnValue(5201);
+    frameCallback!(null, 0.016);
+    expect(onFireAtTarget).toHaveBeenCalledTimes(2);
+  });
+
+  it("neither moves nor fires while downed in deathmatch", () => {
+    vi.spyOn(Date, "now").mockReturnValue(5000);
+
+    const { meshRef, onFireAtTarget, onPositionUpdate } = mountHook({
+      isIt: false,
+      targetIsIt: false,
+      isDowned: true,
+      gameState: deathmatchState,
+      targetPositionRef: { current: [5, 0, 0] },
+    });
+
+    frameCallback!(null, 1);
+
+    expect(meshRef.current.position.x).toBe(0);
+    expect(onFireAtTarget).not.toHaveBeenCalled();
+    expect(onPositionUpdate).not.toHaveBeenCalled();
+    // Downed bots pulse in place as a visual cue.
+    expect(meshRef.current.scale.set).toHaveBeenCalled();
   });
 
   it("clamps flee movement to the position returned by collision resolution", () => {

--- a/src/components/characters/BotCharacter.tsx
+++ b/src/components/characters/BotCharacter.tsx
@@ -19,6 +19,10 @@ export interface BotCharacterProps {
   isIt: boolean;
   targetIsIt: boolean;
   onTagTarget: () => void;
+  /** Fired when the bot wants to shoot its target in deathmatch. */
+  onFireAtTarget?: () => void;
+  /** True while the bot is eliminated and awaiting respawn (deathmatch). */
+  isDowned?: boolean;
   gameState: GameState;
   collisionSystem: React.RefObject<CollisionSystem | null>;
   gotTaggedTimestamp?: number;
@@ -39,6 +43,8 @@ export const BotCharacter: React.FC<BotCharacterProps> = ({
   isIt,
   targetIsIt,
   onTagTarget,
+  onFireAtTarget,
+  isDowned,
   gameState,
   collisionSystem,
   gotTaggedTimestamp,
@@ -65,6 +71,8 @@ export const BotCharacter: React.FC<BotCharacterProps> = ({
     isIt,
     targetIsIt,
     onTagTarget,
+    onFireAtTarget,
+    isDowned,
     onPositionUpdate,
     gameState,
     collisionSystem,

--- a/src/components/characters/useBotAI.ts
+++ b/src/components/characters/useBotAI.ts
@@ -18,6 +18,16 @@ const FLEE_SPEED_MULTIPLIER = 0.7;
 // elapses (it is intentionally much shorter than GameManager's cooldowns).
 const TAG_RETRY_INTERVAL_MS = 200;
 
+// Deathmatch engagement range: the bot advances until within this distance,
+// then holds position and fires. Kept well under the laser's 30-unit range
+// so shots connect reliably.
+const FIRE_RANGE = 10;
+
+// How often the bot retries firing while in range. The actual weapon
+// cooldown is enforced authoritatively by the parent's WeaponManager (same
+// pattern as TAG_RETRY_INTERVAL_MS vs GameManager's tag cooldowns).
+const FIRE_RETRY_INTERVAL_MS = 200;
+
 export interface BotConfig {
   botSpeed: number;
   sprintSpeed: number;
@@ -38,6 +48,10 @@ export interface BotAIProps {
   isIt: boolean;
   targetIsIt: boolean;
   onTagTarget: () => void;
+  /** Fired when the bot wants to shoot its target in deathmatch. */
+  onFireAtTarget?: () => void;
+  /** True while the bot is eliminated and awaiting respawn (deathmatch). */
+  isDowned?: boolean;
   onPositionUpdate: (position: [number, number, number]) => void;
   gameState: GameState;
   collisionSystem: React.RefObject<CollisionSystem | null>;
@@ -62,6 +76,8 @@ export function useBotAI({
   isIt,
   targetIsIt,
   onTagTarget,
+  onFireAtTarget,
+  isDowned,
   onPositionUpdate,
   gameState,
   collisionSystem,
@@ -70,6 +86,7 @@ export function useBotAI({
   meshRef,
 }: BotAIProps): BotAIRefs {
   const lastTagTime = useRef(0);
+  const lastFireTime = useRef(0);
   const isPausedAfterTag = useRef(false);
   const pauseEndTime = useRef(0);
   const lastGotTaggedTimestamp = useRef(0);
@@ -248,6 +265,46 @@ export function useBotAI({
         // Rotate bot to face away from target
         const angle = Math.atan2(direction.x, direction.z);
         meshRef.current.rotation.y = angle;
+      }
+    } else if (gameState.isActive && gameState.mode === "deathmatch") {
+      if (isDowned) {
+        // Eliminated and awaiting respawn - pulse in place and sit out.
+        const pulse = 1 + Math.sin(now * 0.01) * 0.1;
+        meshRef.current.scale.set(pulse, pulse, pulse);
+        return;
+      }
+
+      // Always face the target while engaging
+      const direction = new THREE.Vector3()
+        .subVectors(targetPos, botPos)
+        .normalize();
+      meshRef.current.rotation.y = Math.atan2(direction.x, direction.z);
+
+      if (distance > FIRE_RANGE) {
+        // Advance until within firing range
+        const currentPos = new THREE.Vector3(botPos.x, botPos.y, botPos.z);
+        const newPos = new THREE.Vector3(
+          botPos.x + direction.x * config.botSpeed * delta,
+          botPos.y,
+          botPos.z + direction.z * config.botSpeed * delta,
+        );
+
+        if (collisionSystem.current) {
+          const resolved = collisionSystem.current.checkCollision(
+            currentPos,
+            newPos,
+          );
+          botPos.x = resolved.x;
+          botPos.z = resolved.z;
+        } else {
+          botPos.x = newPos.x;
+          botPos.z = newPos.z;
+        }
+      } else if (now - lastFireTime.current > FIRE_RETRY_INTERVAL_MS) {
+        // In range - fire. The parent's WeaponManager is the authoritative
+        // cooldown gate, so just retry on a short interval.
+        lastFireTime.current = now;
+        onFireAtTarget?.();
       }
     }
 

--- a/src/pages/Solo/components/Bots.tsx
+++ b/src/pages/Solo/components/Bots.tsx
@@ -1,7 +1,9 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useRef } from "react";
 import { BotCharacter } from "../../../components/characters/BotCharacter";
 import type { SoloSceneProps } from "./SoloScene.types";
 import type { BotConfig as FullBotConfig } from "../../../components/characters/useBotAI";
+import { WeaponManager } from "../../../components/combat/WeaponManager";
+import { getSoundManager } from "../../../components/SoundManager";
 import { createTagLogger } from "../../../lib/utils/logger";
 
 const tagDebug = createTagLogger("Bots");
@@ -77,6 +79,11 @@ const Bots: React.FC<
   // Get bot IT status from game manager
   const bot1IsIt = gameManager?.getPlayers().get("bot-1")?.isIt ?? false;
   const bot2IsIt = gameManager?.getPlayers().get("bot-2")?.isIt ?? false;
+  // Downed (awaiting respawn) status for deathmatch
+  const bot1IsDowned =
+    gameManager?.getPlayers().get("bot-1")?.respawnAt !== undefined;
+  const bot2IsDowned =
+    gameManager?.getPlayers().get("bot-2")?.respawnAt !== undefined;
   // Derive player isIt from gameManager to avoid stale React-state race windows
   const playerIsItFromManager =
     gameManager?.getPlayers().get(currentPlayerId)?.isIt ?? playerIsIt;
@@ -156,6 +163,49 @@ const Bots: React.FC<
     }
   }, [gameManager, bot2IsIt, bot1IsIt, setBot1GotTagged]);
 
+  // Shared laser for both bots; WeaponManager tracks per-shooter cooldowns,
+  // so one instance is the authoritative fire-rate gate for bot-1 and bot-2.
+  // Lazily initialized inside the fire handler to satisfy react-hooks/refs.
+  const botWeaponsRef = useRef<WeaponManager | null>(null);
+
+  const fireBotLaser = useCallback(
+    (botId: string, targetId: string) => {
+      if (
+        !gameManager ||
+        gameState.mode !== "deathmatch" ||
+        !gameState.isActive
+      ) {
+        return;
+      }
+
+      if (!botWeaponsRef.current) {
+        botWeaponsRef.current = new WeaponManager();
+        botWeaponsRef.current.equip("laser");
+      }
+
+      const weapon = botWeaponsRef.current.fire(botId);
+      if (!weapon) return; // still on cooldown
+
+      const hitLanded = gameManager.hitPlayer(botId, targetId, weapon.damage);
+      if (hitLanded) {
+        try {
+          getSoundManager()?.playHitSound();
+        } catch {
+          // sound is best-effort only
+        }
+      }
+    },
+    [gameManager, gameState.mode, gameState.isActive],
+  );
+
+  const handleBot1FireAtTarget = useCallback(() => {
+    fireBotLaser("bot-1", botDebugMode ? "bot-2" : currentPlayerId);
+  }, [fireBotLaser, botDebugMode, currentPlayerId]);
+
+  const handleBot2FireAtTarget = useCallback(() => {
+    fireBotLaser("bot-2", "bot-1");
+  }, [fireBotLaser]);
+
   return (
     <>
       <BotCharacter
@@ -183,6 +233,8 @@ const Bots: React.FC<
           }
           handleBot1TagTarget();
         }}
+        onFireAtTarget={handleBot1FireAtTarget}
+        isDowned={bot1IsDowned}
         onPositionUpdate={handleBot1PositionUpdate}
         gameState={gameState}
         collisionSystem={collisionSystemRef}
@@ -198,6 +250,8 @@ const Bots: React.FC<
           targetIsIt={bot1IsIt}
           isPaused={isPaused}
           onTagTarget={handleBot2TagTarget}
+          onFireAtTarget={handleBot2FireAtTarget}
+          isDowned={bot2IsDowned}
           onPositionUpdate={handleBot2PositionUpdate}
           gameState={gameState}
           collisionSystem={collisionSystemRef}

--- a/src/pages/Solo/components/__tests__/Bots.test.tsx
+++ b/src/pages/Solo/components/__tests__/Bots.test.tsx
@@ -189,6 +189,57 @@ describe("Bots", () => {
     expect(gm.getPlayers().get("bot-1")?.isIt).toBe(false);
   });
 
+  it("routes bot laser fire through hitPlayer with the weapon cooldown in deathmatch", () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(5000);
+
+    const gm = new GameManager();
+    gm.addPlayer(makeBotPlayer("bot-1", "Bot1"));
+    gm.addPlayer(makeBotPlayer("player-1", "Player1"));
+    gm.startDeathmatchGame(120, 10);
+
+    const props = buildProps({
+      gameManager: gm as unknown as React.ComponentProps<
+        typeof Bots
+      >["gameManager"],
+      gameState: gm.getGameState(),
+    });
+
+    render(<Bots {...props} />);
+    const fire = botPropsByRender[0].onFireAtTarget as () => void;
+
+    fire();
+    expect(gm.getPlayers().get("player-1")?.health).toBe(90);
+
+    // Still within the laser's 500ms cooldown - the shot is gated.
+    fire();
+    expect(gm.getPlayers().get("player-1")?.health).toBe(90);
+
+    // Cooldown elapsed - the next shot lands.
+    nowSpy.mockReturnValue(5600);
+    fire();
+    expect(gm.getPlayers().get("player-1")?.health).toBe(80);
+  });
+
+  it("marks a bot as downed while it awaits respawn in deathmatch", () => {
+    vi.spyOn(Date, "now").mockReturnValue(5000);
+
+    const gm = new GameManager();
+    gm.addPlayer(makeBotPlayer("bot-1", "Bot1"));
+    gm.addPlayer(makeBotPlayer("player-1", "Player1"));
+    gm.startDeathmatchGame(120, 10);
+    gm.hitPlayer("player-1", "bot-1", 1000); // down the bot
+
+    const props = buildProps({
+      gameManager: gm as unknown as React.ComponentProps<
+        typeof Bots
+      >["gameManager"],
+      gameState: gm.getGameState(),
+    });
+
+    render(<Bots {...props} />);
+    expect(botPropsByRender[0].isDowned).toBe(true);
+  });
+
   it("allows bot-2 to tag bot-1 when bot-2 is IT", () => {
     const setBot1GotTagged = vi.fn();
     const players = new Map<string, { isIt: boolean }>([


### PR DESCRIPTION
## Summary

Builds on #241/#242 to turn deathmatch into a real firefight against bots:

- **Bot combat AI**: `useBotAI` gains a deathmatch branch — the bot faces its target, advances until within `FIRE_RANGE` (10 units, well under the laser's 30-unit range), then holds position and fires via `onFireAtTarget` on a 200ms retry interval. The actual fire-rate gate is the parent's `WeaponManager` (the same authoritative-cooldown pattern as tagging vs `GameManager.tagPlayer`).
- **Downed bots sit out**: `isDowned` (derived from `Player.respawnAt`) makes an eliminated bot pulse in place — no movement, no firing — until DeathmatchMode respawns it.
- **Wiring**: `Bots.tsx` lazily creates a shared laser `WeaponManager` (per-shooter cooldowns) and routes `fireBotLaser` through `gameManager.hitPlayer()`, so bot kills count on the scoreboard and the hit sound plays on landed shots. Bot-1 targets the player (bot-2 in debug mode); bot-2 targets bot-1.

## Tests

5 new tests: 3 in `useBotAI.unit.test.tsx` (advances when beyond fire range, holds + fires on the retry interval in range, downed bots neither move nor fire) and 2 in `Bots.test.tsx` (laser fire routes through `hitPlayer` respecting the 500ms weapon cooldown; downed status pass-through).

Full Docker suite: **66 files, 414 passed / 5 skipped** (pre-push hook re-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)