### PR TITLE
Phase D: CTFMode game handler with teams, flags, pickup/capture

### DIFF
--- a/docs/MULTIPLAYER_SHOOTER_ROADMAP.md
+++ b/docs/MULTIPLAYER_SHOOTER_ROADMAP.md
@@ -1,8 +1,9 @@
 # Multiplayer Shooter Roadmap — "Robot Conker's Bad Fur Day"
 
 **Status:** Phase 1 (tag stabilization) complete. Phase A (pluggable game modes)
-complete. Phase B combat primitives (WeaponManager, projectile hit detection, Player
-health/respawn fields) complete — UI wiring (visible laser mechanic) is next.
+complete. Phase B (combat primitives) complete. Phase C (deathmatch) complete end to
+end — backend, gameplay wiring, and bot combat AI. Phase D (CTF) backend (`CTFMode`,
+flags, teams, pickup/capture) is implemented — UI/bot wiring is next.
 
 ## Context
 
@@ -94,36 +95,47 @@ players, shooterId)` casts a ray and returns the closest hit `{ hitPlayerId, dis
 
 ---
 
-## Phase C — Deathmatch (maps to the build guide's `BeachMode`)
+## Phase C — Deathmatch (maps to the build guide's `BeachMode`) ✅ done
 
-- **`DeathmatchMode`** implements `GameModeHandler`: tracks `kills: Map<playerId,
-number>`, a `killLimit`, and a respawn timer (`respawnAt` from Phase B).
-- `onAction({ type: "hit", attackerId, targetId })`: apply damage via `WeaponManager`'s
-  configured damage; on `health <= 0`, increment `kills`, set `respawnAt`, zero `health`
-  for respawn.
-- **Scoreboard**: extend `GameUI.tsx`'s existing score display (it already renders
-  `gameState.scores`) to show `kills` per player when `mode === "deathmatch"`.
+- ✅ **`DeathmatchMode`** implements `GameModeHandler`: tracks kills via
+  `gameState.scores`, a `killLimit`, and a respawn timer (`respawnAt` from Phase B).
+- ✅ `onAction({ type: "hit", attackerId, targetId, damage })`: apply damage; on
+  `health <= 0`, increment the attacker's kill score, set `respawnAt`, and the target
+  sits out until the respawn delay elapses.
+- ✅ **Gameplay wiring**: Solo mode's "Start Deathmatch" lobby button, live health/kill
+  scoreboard in `GameUI.tsx`, and per-frame position sync (`GameManager.updatePlayerPosition`)
+  so projectile hits land on moving targets.
+- ✅ **Bot combat AI**: `useBotAI` gained a deathmatch branch — bots chase to
+  `FIRE_RANGE`, fire lasers via a shared `WeaponManager` (authoritative cooldown), and
+  sit out (pulsing) while downed awaiting respawn.
 
-**Acceptance:** regression tests for kill tracking, respawn timing, and end-of-game
-results, mirroring `endGame()`'s existing results-sorting test in
-`gameManager.core.test.ts`.
+**Acceptance:** regression tests for kill tracking, respawn timing, end-of-game
+results, gameplay wiring, and bot fire behavior all pass (`gameManager.deathmatch.test.ts`,
+`usePlayerWeapon.test.ts`, `GameUI.test.tsx`, `useBotAI.unit.test.tsx`, `Bots.test.tsx`).
 
 ---
 
 ## Phase D — Capture the Flag (maps to the build guide's `HeistMode`)
 
-- **Teams**: add `team?: "a" | "b"` to `Player`. Team assignment happens in
-  `onStart` (alternate players, or balance by join order).
-- **Flag entities**: simple data objects `{ team: "a" | "b", position: [number, number,
-number], carrierId?: string }`, stored in `CTFMode` state (not on `Player`).
-- **Capture zones**: reuse the bounds-check pattern from the build guide's
-  `TriggerVolume` (Section 3.4) — a simple `containsPoint`-style check against each team's
-  base position, run in `onTick`.
-- `onAction({ type: "pickupFlag" | "captureFlag", playerId })` mutates flag
-  `carrierId`/`position` and increments `gameState.scores[team]` on capture.
+- ✅ **Teams**: `Player.team?: "a" | "b"`. `CTFMode.onStart` assigns teams by
+  alternating join order.
+- ✅ **Flag entities**: `CTFFlag { team, position, basePosition, carrierId? }`, stored
+  on `gameState.flags` (not on `Player`), one per team, spawned at `TEAM_A_BASE`/
+  `TEAM_B_BASE`.
+- ✅ **Pickup/capture**: `onAction({ type: "pickupFlag" | "captureFlag", playerId })` —
+  pickup only succeeds for the _enemy_ team's unguarded flag within `PICKUP_RADIUS`;
+  capture only succeeds while carrying the enemy flag and standing within
+  `CAPTURE_RADIUS` of your own team's base, and increments `gameState.scores[team]`.
+- ✅ **Carried-flag tracking**: `onTick` syncs a carried flag's position to its
+  carrier; `onPlayerRemoved` returns a dropped flag to its base.
+- **Remaining — UI/bot wiring** (follow-up PR, mirrors Phase C's split): Solo mode
+  "Start CTF" lobby entry, flag visuals + pickup/capture keybind or proximity trigger,
+  team-colored HUD/scoreboard, and bot AI for pickup/capture/defend behavior.
 
-**Acceptance:** regression tests for pickup/capture/return sequences and the
-"can't capture your own team's flag" edge case.
+**Acceptance:** ✅ `gameManager.ctf.test.ts` covers team assignment, flag spawning,
+pickup (including the "can't capture your own team's flag" edge case via the
+pickup-rejection check), range gating, flag-follows-carrier, capture/score/return,
+carrier-disconnect, and end-of-game team-score results.
 
 ---
 

--- a/src/__tests__/gameManager.ctf.test.ts
+++ b/src/__tests__/gameManager.ctf.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import GameManager, { type Player } from "../components/GameManager";
+import { TEAM_A_BASE, TEAM_B_BASE } from "../components/gameModes/CTFMode";
+
+const makePlayer = (
+  id: string,
+  name: string,
+  position: [number, number, number] = [0, 0, 0],
+): Player => ({
+  id,
+  name,
+  position,
+  rotation: [0, 0, 0],
+});
+
+describe("GameManager CTF", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starting CTF assigns alternating teams and spawns each team's flag at its base", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+    manager.addPlayer(makePlayer("p3", "P3"));
+    manager.addPlayer(makePlayer("p4", "P4"));
+
+    expect(manager.startCTFGame(180)).toBe(true);
+
+    const state = manager.getGameState();
+    expect(state.mode).toBe("ctf");
+    expect(state.isActive).toBe(true);
+    expect(state.scores).toEqual({ a: 0, b: 0 });
+
+    const players = manager.getPlayers();
+    expect(players.get("p1")?.team).toBe("a");
+    expect(players.get("p2")?.team).toBe("b");
+    expect(players.get("p3")?.team).toBe("a");
+    expect(players.get("p4")?.team).toBe("b");
+
+    expect(state.flags).toEqual([
+      { team: "a", position: TEAM_A_BASE, basePosition: TEAM_A_BASE },
+      { team: "b", position: TEAM_B_BASE, basePosition: TEAM_B_BASE },
+    ]);
+  });
+
+  it("a player can pick up the enemy team's flag when standing near it", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1", TEAM_B_BASE)); // team a, standing at team b's base
+    manager.addPlayer(makePlayer("p2", "P2"));
+    manager.startCTFGame();
+
+    expect(manager.pickupFlag("p1")).toBe(true);
+
+    const flags = manager.getGameState().flags!;
+    expect(flags.find((f) => f.team === "b")?.carrierId).toBe("p1");
+  });
+
+  it("a player cannot pick up their own team's flag", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1", TEAM_A_BASE)); // team a, standing at their own base
+    manager.addPlayer(makePlayer("p2", "P2"));
+    manager.startCTFGame();
+
+    expect(manager.pickupFlag("p1")).toBe(false);
+
+    const flags = manager.getGameState().flags!;
+    expect(flags.find((f) => f.team === "a")?.carrierId).toBeUndefined();
+  });
+
+  it("pickup fails when the player is out of range of the enemy flag", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1", [0, 0, 0])); // far from either base
+    manager.addPlayer(makePlayer("p2", "P2"));
+    manager.startCTFGame();
+
+    expect(manager.pickupFlag("p1")).toBe(false);
+  });
+
+  it("a carried flag follows its carrier as the game ticks", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1", TEAM_B_BASE)); // team a
+    manager.addPlayer(makePlayer("p2", "P2"));
+    manager.startCTFGame();
+    manager.pickupFlag("p1");
+
+    manager.updatePlayerPosition("p1", [3, 0.5, 4]);
+    manager.updateGameTimer(0.1);
+
+    const flags = manager.getGameState().flags!;
+    expect(flags.find((f) => f.team === "b")?.position).toEqual([3, 0.5, 4]);
+  });
+
+  it("capturing the enemy flag at your own base scores a point and returns the flag", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1", TEAM_B_BASE)); // team a
+    manager.addPlayer(makePlayer("p2", "P2"));
+    manager.startCTFGame();
+    manager.pickupFlag("p1");
+
+    // Carry the flag home to team a's base.
+    manager.updatePlayerPosition("p1", TEAM_A_BASE);
+
+    expect(manager.captureFlag("p1")).toBe(true);
+    expect(manager.getGameState().scores["a"]).toBe(1);
+
+    const flags = manager.getGameState().flags!;
+    const flagB = flags.find((f) => f.team === "b")!;
+    expect(flagB.carrierId).toBeUndefined();
+    expect(flagB.position).toEqual(TEAM_B_BASE);
+  });
+
+  it("capture fails if the player isn't carrying a flag", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1", TEAM_A_BASE));
+    manager.addPlayer(makePlayer("p2", "P2"));
+    manager.startCTFGame();
+
+    expect(manager.captureFlag("p1")).toBe(false);
+    expect(manager.getGameState().scores["a"]).toBe(0);
+  });
+
+  it("capture fails outside the capture zone", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1", TEAM_B_BASE)); // team a
+    manager.addPlayer(makePlayer("p2", "P2"));
+    manager.startCTFGame();
+    manager.pickupFlag("p1");
+
+    // Still at team b's base, not home yet.
+    expect(manager.captureFlag("p1")).toBe(false);
+    expect(manager.getGameState().scores["a"]).toBe(0);
+  });
+
+  it("rejects flag actions outside an active CTF game", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1", TEAM_B_BASE));
+    manager.addPlayer(makePlayer("p2", "P2"));
+
+    // Not started yet
+    expect(manager.pickupFlag("p1")).toBe(false);
+    expect(manager.captureFlag("p1")).toBe(false);
+
+    // Started in tag mode instead
+    manager.startTagGame();
+    expect(manager.pickupFlag("p1")).toBe(false);
+  });
+
+  it("returns a carried flag to base if its carrier is removed mid-game", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1", TEAM_B_BASE)); // team a
+    manager.addPlayer(makePlayer("p2", "P2"));
+    manager.startCTFGame();
+    manager.pickupFlag("p1");
+
+    manager.removePlayer("p1");
+
+    const flags = manager.getGameState().flags!;
+    const flagB = flags.find((f) => f.team === "b")!;
+    expect(flagB.carrierId).toBeUndefined();
+    expect(flagB.position).toEqual(TEAM_B_BASE);
+  });
+
+  it("ends the game with results based on each player's team score", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1", TEAM_B_BASE)); // team a
+    manager.addPlayer(makePlayer("p2", "P2", TEAM_A_BASE)); // team b
+    manager.startCTFGame();
+
+    manager.pickupFlag("p1");
+    manager.updatePlayerPosition("p1", TEAM_A_BASE);
+    manager.captureFlag("p1"); // team a scores 1
+
+    const results = manager.endGame();
+    expect(results).toEqual([
+      { id: "p1", name: "P1", score: 1 },
+      { id: "p2", name: "P2", score: 0 },
+    ]);
+  });
+});

--- a/src/components/GameManager.ts
+++ b/src/components/GameManager.ts
@@ -1,7 +1,8 @@
 import { createLogger } from "../lib/utils/logger";
-import type { GameModeHandler } from "./gameModes/GameModeHandler";
+import type { CTFFlag, GameModeHandler } from "./gameModes/GameModeHandler";
 import TagMode from "./gameModes/TagMode";
 import DeathmatchMode from "./gameModes/DeathmatchMode";
+import CTFMode from "./gameModes/CTFMode";
 
 const log = createLogger("GameManager");
 
@@ -9,6 +10,7 @@ export type GameMode =
   | "none"
   | "tag"
   | "deathmatch"
+  | "ctf"
   | "collectible"
   | "race"
   | "solo";
@@ -22,6 +24,8 @@ export interface GameState {
   roundStartTime?: number;
   /** Kills required to win deathmatch. */
   killLimit?: number;
+  /** Flag entities for capture-the-flag. */
+  flags?: CTFFlag[];
 }
 
 export interface TagGameState extends GameState {
@@ -46,6 +50,8 @@ export interface Player {
   maxHealth?: number;
   /** Timestamp (ms) when a downed player becomes eligible to respawn. */
   respawnAt?: number;
+  /** Team assignment for capture-the-flag. */
+  team?: "a" | "b";
 }
 
 export class GameManager {
@@ -92,6 +98,10 @@ export class GameManager {
       this.gameState.mode === "tag" &&
       this.gameState.itPlayerId === playerId
     ) {
+      this.mode.onPlayerRemoved(playerId, this.players, this.gameState);
+      this.callbacks.onGameStateUpdate?.(this.gameState);
+    } else if (this.gameState.mode === "ctf" && this.gameState.isActive) {
+      // Let CTFMode return any flag the departing player was carrying.
       this.mode.onPlayerRemoved(playerId, this.players, this.gameState);
       this.callbacks.onGameStateUpdate?.(this.gameState);
     }
@@ -205,6 +215,62 @@ export class GameManager {
 
     const accepted = this.mode.onAction(
       { type: "hit", attackerId, targetId, damage },
+      this.players,
+      this.gameState,
+    );
+
+    if (accepted) {
+      this.callbacks.onGameStateUpdate?.(this.gameState);
+      this.callbacks.onPlayerUpdate?.(this.players);
+    }
+
+    return accepted;
+  }
+
+  startCTFGame(duration: number = 180) {
+    this.gameState = {
+      mode: "ctf",
+      isActive: true,
+      timeRemaining: duration,
+      scores: {},
+      roundStartTime: Date.now(),
+    };
+
+    this.mode = new CTFMode();
+    this.mode.onStart(this.players, this.gameState);
+
+    this.callbacks.onGameStateUpdate?.(this.gameState);
+    this.callbacks.onPlayerUpdate?.(this.players);
+    log.debug(`CTF game started!`);
+    return true;
+  }
+
+  pickupFlag(playerId: string): boolean {
+    if (this.gameState.mode !== "ctf" || !this.gameState.isActive) {
+      return false;
+    }
+
+    const accepted = this.mode.onAction(
+      { type: "pickupFlag", playerId },
+      this.players,
+      this.gameState,
+    );
+
+    if (accepted) {
+      this.callbacks.onGameStateUpdate?.(this.gameState);
+      this.callbacks.onPlayerUpdate?.(this.players);
+    }
+
+    return accepted;
+  }
+
+  captureFlag(playerId: string): boolean {
+    if (this.gameState.mode !== "ctf" || !this.gameState.isActive) {
+      return false;
+    }
+
+    const accepted = this.mode.onAction(
+      { type: "captureFlag", playerId },
       this.players,
       this.gameState,
     );

--- a/src/components/gameModes/CTFMode.ts
+++ b/src/components/gameModes/CTFMode.ts
@@ -1,0 +1,163 @@
+import { createLogger } from "../../lib/utils/logger";
+import type { GameState, Player } from "../GameManager";
+import type {
+  GameAction,
+  GameModeHandler,
+  GameResult,
+} from "./GameModeHandler";
+
+const log = createLogger("CTFMode");
+
+/** Home base / capture zone for team "a", at the west end of the arena. */
+export const TEAM_A_BASE: [number, number, number] = [-15, 0.5, 0];
+/** Home base / capture zone for team "b", at the east end of the arena. */
+export const TEAM_B_BASE: [number, number, number] = [15, 0.5, 0];
+
+function distance(
+  a: [number, number, number],
+  b: [number, number, number],
+): number {
+  const dx = a[0] - b[0];
+  const dy = a[1] - b[1];
+  const dz = a[2] - b[2];
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+/**
+ * Capture-the-flag rules: players alternate onto team "a"/"b" at the start
+ * of the round, each defending a flag at their team's base. Picking up the
+ * enemy flag and carrying it back to your own base scores a point for your
+ * team and returns the flag to its base.
+ */
+export class CTFMode implements GameModeHandler {
+  private readonly PICKUP_RADIUS = 1.5;
+  private readonly CAPTURE_RADIUS = 2;
+
+  onStart(players: Map<string, Player>, gameState: GameState): void {
+    gameState.scores = { a: 0, b: 0 };
+    gameState.flags = [
+      { team: "a", position: [...TEAM_A_BASE], basePosition: [...TEAM_A_BASE] },
+      { team: "b", position: [...TEAM_B_BASE], basePosition: [...TEAM_B_BASE] },
+    ];
+
+    let i = 0;
+    players.forEach((player) => {
+      player.team = i % 2 === 0 ? "a" : "b";
+      i++;
+    });
+  }
+
+  onTick(
+    deltaTime: number,
+    players: Map<string, Player>,
+    gameState: GameState,
+  ): void {
+    gameState.timeRemaining -= deltaTime;
+
+    // Carried flags follow their carrier's position.
+    gameState.flags?.forEach((flag) => {
+      if (flag.carrierId === undefined) return;
+      const carrier = players.get(flag.carrierId);
+      if (carrier) flag.position = carrier.position;
+    });
+  }
+
+  onAction(
+    action: GameAction,
+    players: Map<string, Player>,
+    gameState: GameState,
+  ): boolean {
+    if (action.type === "pickupFlag") {
+      return this.pickupFlag(action.playerId, players, gameState);
+    }
+    if (action.type === "captureFlag") {
+      return this.captureFlag(action.playerId, players, gameState);
+    }
+    return false;
+  }
+
+  private pickupFlag(
+    playerId: string,
+    players: Map<string, Player>,
+    gameState: GameState,
+  ): boolean {
+    const player = players.get(playerId);
+    if (!player || !player.team || !gameState.flags) return false;
+
+    // Only the enemy team's flag can be picked up, and only while it's
+    // sitting unguarded (not already carried).
+    const flag = gameState.flags.find(
+      (f) => f.team !== player.team && f.carrierId === undefined,
+    );
+    if (!flag) return false;
+
+    if (distance(player.position, flag.position) > this.PICKUP_RADIUS) {
+      return false;
+    }
+
+    flag.carrierId = playerId;
+    log.debug(`${player.name} picked up team ${flag.team}'s flag!`);
+    return true;
+  }
+
+  private captureFlag(
+    playerId: string,
+    players: Map<string, Player>,
+    gameState: GameState,
+  ): boolean {
+    const player = players.get(playerId);
+    if (!player || !player.team || !gameState.flags) return false;
+
+    const carriedFlag = gameState.flags.find((f) => f.carrierId === playerId);
+    if (!carriedFlag) return false;
+
+    const ownFlag = gameState.flags.find((f) => f.team === player.team);
+    if (!ownFlag) return false;
+
+    if (distance(player.position, ownFlag.basePosition) > this.CAPTURE_RADIUS) {
+      return false;
+    }
+
+    gameState.scores[player.team] = (gameState.scores[player.team] ?? 0) + 1;
+    carriedFlag.carrierId = undefined;
+    carriedFlag.position = [...carriedFlag.basePosition];
+
+    log.debug(
+      `${player.name} captured team ${carriedFlag.team}'s flag for team ${player.team}! (${gameState.scores[player.team]} captures)`,
+    );
+    return true;
+  }
+
+  onPlayerRemoved(
+    playerId: string,
+    _players: Map<string, Player>,
+    gameState: GameState,
+  ): void {
+    // A departing carrier drops the flag back at its base rather than
+    // leaving it stuck on a player who no longer exists.
+    gameState.flags?.forEach((flag) => {
+      if (flag.carrierId === playerId) {
+        flag.carrierId = undefined;
+        flag.position = [...flag.basePosition];
+      }
+    });
+  }
+
+  onEnd(players: Map<string, Player>, gameState: GameState): GameResult[] {
+    const results = Array.from(players.entries())
+      .map(([id, player]) => ({
+        id,
+        name: player.name,
+        score: gameState.scores[player.team ?? ""] ?? 0,
+      }))
+      .sort((a, b) => b.score - a.score);
+
+    players.forEach((player) => {
+      player.team = undefined;
+    });
+
+    return results;
+  }
+}
+
+export default CTFMode;

--- a/src/components/gameModes/GameModeHandler.ts
+++ b/src/components/gameModes/GameModeHandler.ts
@@ -6,6 +6,18 @@ export interface GameResult {
   score: number;
 }
 
+/** A capture-the-flag flag, owned/defended by one team. */
+export interface CTFFlag {
+  /** Team this flag belongs to and must be defended by. */
+  team: "a" | "b";
+  /** Current position (at its base, or following its carrier). */
+  position: [number, number, number];
+  /** Home position; also the center of this team's capture zone. */
+  basePosition: [number, number, number];
+  /** ID of the player currently carrying this flag, if any. */
+  carrierId?: string;
+}
+
 export type GameAction =
   | {
       type: "tag";
@@ -17,6 +29,14 @@ export type GameAction =
       attackerId: string;
       targetId: string;
       damage: number;
+    }
+  | {
+      type: "pickupFlag";
+      playerId: string;
+    }
+  | {
+      type: "captureFlag";
+      playerId: string;
     };
 
 /**


### PR DESCRIPTION
## Summary

Backend scaffolding for Capture the Flag, following the exact pattern established by `DeathmatchMode` (PRs #241-#243). Per the roadmap's Phase C/D split, this is **backend only** — UI/bot wiring for CTF is a follow-up PR.

- `GameModeHandler.ts`: adds a `CTFFlag` type (`team`, `position`, `basePosition`, `carrierId?`) and two new `GameAction` variants: `pickupFlag` and `captureFlag`.
- `CTFMode.ts` (new): implements `GameModeHandler`.
  - `onStart`: alternates players onto team `"a"`/`"b"` by join order, resets `gameState.scores` to `{ a: 0, b: 0 }`, and spawns each team's flag at its base (`TEAM_A_BASE`/`TEAM_B_BASE`).
  - `pickupFlag`: succeeds only for the *enemy* team's unguarded flag, within `PICKUP_RADIUS` of the player.
  - `captureFlag`: succeeds only while carrying the enemy flag and standing within `CAPTURE_RADIUS` of your own team's base; increments `gameState.scores[team]` and returns the flag to its base.
  - `onTick`: syncs a carried flag's position to its carrier.
  - `onPlayerRemoved`: returns a departing carrier's flag to base.
  - `onEnd`: per-player results based on their team's score.
- `GameManager.ts`: adds `"ctf"` to `GameMode`, `Player.team?: "a" | "b"`, `GameState.flags?: CTFFlag[]`, and `startCTFGame`/`pickupFlag`/`captureFlag` methods following the `startDeathmatchGame`/`hitPlayer` pattern. `removePlayer` now lets `CTFMode` return a departing carrier's flag.
- `docs/MULTIPLAYER_SHOOTER_ROADMAP.md`: marks Phase C fully done (backend + gameplay + bot AI) and Phase D backend done, with UI/bot wiring noted as the next increment.

## Test plan

- [x] New `src/__tests__/gameManager.ctf.test.ts` (11 tests): team assignment + flag spawn, pickup of enemy flag in range, rejecting pickup of your own flag, out-of-range pickup, flag-follows-carrier on tick, capture scores + returns the flag, capture failure without a carried flag, capture failure outside the zone, rejection outside an active CTF game, carrier-disconnect drops the flag, end-of-game team-score results.
- [x] `npx tsc --noEmit` (root config) — passes.
- [x] `npm run lint -- --max-warnings=0` via Docker — passes.
- [x] Full suite via Docker: **425 passed / 5 skipped / 67 files** (up from 414/5/66).
- [x] Pre-push hook re-ran the full suite — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)