### PR TITLE
Phase D part 2: wire CTF into Solo gameplay

### DIFF
--- a/docs/MULTIPLAYER_SHOOTER_ROADMAP.md
+++ b/docs/MULTIPLAYER_SHOOTER_ROADMAP.md
@@ -2,8 +2,9 @@
 
 **Status:** Phase 1 (tag stabilization) complete. Phase A (pluggable game modes)
 complete. Phase B (combat primitives) complete. Phase C (deathmatch) complete end to
-end — backend, gameplay wiring, and bot combat AI. Phase D (CTF) backend (`CTFMode`,
-flags, teams, pickup/capture) is implemented — UI/bot wiring is next.
+end — backend, gameplay wiring, and bot combat AI. Phase D (CTF) backend and gameplay
+wiring (`CTFMode`, flags, teams, pickup/capture, Solo "Start CTF", team/flag HUD) are
+implemented — bot AI for CTF is next.
 
 ## Context
 
@@ -128,14 +129,21 @@ results, gameplay wiring, and bot fire behavior all pass (`gameManager.deathmatc
   `CAPTURE_RADIUS` of your own team's base, and increments `gameState.scores[team]`.
 - ✅ **Carried-flag tracking**: `onTick` syncs a carried flag's position to its
   carrier; `onPlayerRemoved` returns a dropped flag to its base.
-- **Remaining — UI/bot wiring** (follow-up PR, mirrors Phase C's split): Solo mode
-  "Start CTF" lobby entry, flag visuals + pickup/capture keybind or proximity trigger,
-  team-colored HUD/scoreboard, and bot AI for pickup/capture/defend behavior.
+- ✅ **Gameplay wiring**: Solo mode's "Start CTF" lobby button (gated on 2+ players,
+  mirroring "Start Deathmatch"), a team-colored HUD showing team assignment and
+  team scores (`gameState.scores["a"]`/`["b"]`), a "carrying flag" indicator, and
+  proximity-based pickup/capture (`GameManager.pickupFlag`/`captureFlag` called from
+  `Solo.tsx`'s per-frame position sync).
+- **Remaining — bot AI** (follow-up PR, mirrors Phase C's split): bots currently stand
+  idle during CTF; add pickup/capture/defend behavior to `useBotAI` (e.g. chase the
+  enemy flag when unguarded, return to base when carrying, defend the home flag
+  otherwise).
 
 **Acceptance:** ✅ `gameManager.ctf.test.ts` covers team assignment, flag spawning,
 pickup (including the "can't capture your own team's flag" edge case via the
 pickup-rejection check), range gating, flag-follows-carrier, capture/score/return,
-carrier-disconnect, and end-of-game team-score results.
+carrier-disconnect, and end-of-game team-score results. ✅ `GameUI.test.tsx` covers the
+"Start CTF" lobby button and the team/score/carrying-flag HUD.
 
 ---
 

--- a/src/components/GameUI.tsx
+++ b/src/components/GameUI.tsx
@@ -176,6 +176,56 @@ const GameUI: React.FC<GameUIProps> = ({
           </>
         )}
 
+        {gameState.mode === "ctf" && (
+          <>
+            <div
+              style={{
+                marginBottom: isMinimal ? "2px" : "6px",
+                padding: isMinimal ? "2px 3px" : "4px 8px",
+                backgroundColor:
+                  currentPlayer?.team === "a"
+                    ? "rgba(74, 144, 226, 0.3)"
+                    : "rgba(220, 53, 69, 0.3)",
+                borderRadius: "3px",
+                border:
+                  currentPlayer?.team === "a"
+                    ? "1px solid #4a90e2"
+                    : "1px solid #dc3545",
+                fontSize: isMinimal ? "8px" : isMobile ? "10px" : "11px",
+              }}
+            >
+              {currentPlayer?.team === "a" ? "🔵 Team A" : "🔴 Team B"}
+            </div>
+
+            {!isMinimal && (
+              <div
+                style={{
+                  marginBottom: "6px",
+                  fontSize: isMobile ? "9px" : "10px",
+                }}
+              >
+                🔵 {gameState.scores["a"] ?? 0} - {gameState.scores["b"] ?? 0}{" "}
+                🔴
+              </div>
+            )}
+
+            {gameState.flags?.some(
+              (flag) => flag.carrierId === currentPlayerId,
+            ) && (
+              <div
+                style={{
+                  marginBottom: isMinimal ? "2px" : "6px",
+                  fontSize: isMinimal ? "8px" : isMobile ? "9px" : "10px",
+                  color: "#ffff64",
+                  fontWeight: "bold",
+                }}
+              >
+                🚩 Carrying flag! Return to base!
+              </div>
+            )}
+          </>
+        )}
+
         <button
           onClick={onEndGame}
           style={{
@@ -313,6 +363,28 @@ const GameUI: React.FC<GameUIProps> = ({
               }}
             >
               {isMinimal || isMobile ? "🔫" : "Start Deathmatch"}
+            </button>
+          )}
+
+          {players.size >= 2 && (
+            <button
+              onClick={() => onStartGame("ctf")}
+              style={{
+                padding: isMinimal
+                  ? "3px 5px"
+                  : isMobile
+                    ? "6px 8px"
+                    : "6px 10px",
+                backgroundColor: "rgba(155, 89, 182, 0.8)",
+                border: "1px solid #9b59b6",
+                borderRadius: "3px",
+                color: "white",
+                cursor: "pointer",
+                fontSize: isMinimal ? "14px" : isMobile ? "14px" : "11px",
+                width: "100%",
+              }}
+            >
+              {isMinimal || isMobile ? "🚩" : "Start CTF"}
             </button>
           )}
 

--- a/src/components/__tests__/GameUI.test.tsx
+++ b/src/components/__tests__/GameUI.test.tsx
@@ -89,6 +89,9 @@ describe("GameUI", () => {
     fireEvent.click(screen.getByText("Start Deathmatch"));
     expect(onStartGame).toHaveBeenCalledWith("deathmatch");
 
+    fireEvent.click(screen.getByText("Start CTF"));
+    expect(onStartGame).toHaveBeenCalledWith("ctf");
+
     fireEvent.click(screen.getByText("⏹️ Stop Debug"));
     expect(onToggleDebug).toHaveBeenCalled();
   });
@@ -123,5 +126,49 @@ describe("GameUI", () => {
     expect(screen.getByText("❤️ 70 / 100")).toBeInTheDocument();
     expect(screen.getByText("💀 Player Two: 5 / 10")).toBeInTheDocument();
     expect(screen.getByText("💀 Player One: 2 / 10")).toBeInTheDocument();
+  });
+
+  it("renders team, scores, and carried-flag status during an active CTF game", () => {
+    const players = mkPlayers();
+    players.get("p1")!.team = "a";
+    players.get("p2")!.team = "b";
+
+    const gameState: GameState = {
+      mode: "ctf",
+      isActive: true,
+      timeRemaining: 90,
+      scores: { a: 1, b: 2 },
+      roundStartTime: Date.now(),
+      flags: [
+        {
+          team: "a",
+          position: [-15, 0.5, 0],
+          basePosition: [-15, 0.5, 0],
+        },
+        {
+          team: "b",
+          position: [0, 0.5, 0],
+          basePosition: [15, 0.5, 0],
+          carrierId: "p1",
+        },
+      ],
+    };
+
+    render(
+      <GameUI
+        gameState={gameState}
+        players={players}
+        currentPlayerId="p1"
+        onStartGame={vi.fn()}
+        onEndGame={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/CTF GAME/)).toBeInTheDocument();
+    expect(screen.getByText("🔵 Team A")).toBeInTheDocument();
+    expect(screen.getByText("🔵 1 - 2 🔴")).toBeInTheDocument();
+    expect(
+      screen.getByText("🚩 Carrying flag! Return to base!"),
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/Solo.tsx
+++ b/src/pages/Solo.tsx
@@ -418,8 +418,23 @@ const Solo: React.FC = () => {
     (position: [number, number, number]) => {
       playerPositionRef.current = position;
       gameManager.current?.updatePlayerPosition(currentPlayerId, position);
+
+      if (
+        gameState.mode === "ctf" &&
+        gameState.isActive &&
+        gameManager.current
+      ) {
+        if (gameManager.current.pickupFlag(currentPlayerId)) {
+          addNotification(
+            "You grabbed the enemy flag! Get it to your base!",
+            "warning",
+          );
+        } else if (gameManager.current.captureFlag(currentPlayerId)) {
+          addNotification("Flag captured! Your team scores!", "success");
+        }
+      }
     },
-    [currentPlayerId],
+    [currentPlayerId, gameState.mode, gameState.isActive, addNotification],
   );
 
   // Bot position tracking - use refs to avoid re-render loops AND update clients object for collision
@@ -554,6 +569,17 @@ const Solo: React.FC = () => {
       setGameState(newGameState);
       addNotification(
         `Deathmatch started! First to ${newGameState.killLimit} kills wins!`,
+        "warning",
+      );
+      return;
+    }
+
+    if (mode === "ctf") {
+      gameManager.current.startCTFGame();
+      const newGameState = gameManager.current.getGameState();
+      setGameState(newGameState);
+      addNotification(
+        "Capture the Flag started! Grab the enemy flag and bring it home!",
         "warning",
       );
       return;


### PR DESCRIPTION
## Summary

Follow-up to #244 (CTFMode backend). Wires capture-the-flag into Solo gameplay,
mirroring how Phase C's deathmatch wiring (#242) was layered onto its backend (#241).

- "Start CTF" lobby button in `GameUI.tsx`, gated on 2+ players like "Start Deathmatch"
  (label "Start CTF" / "🚩", purple styling to distinguish from tag/deathmatch).
- Active-game HUD for CTF mode: team indicator (🔵 Team A / 🔴 Team B), live team
  scores (`gameState.scores["a"]`/`["b"]`), and a "Carrying flag! Return to base!"
  indicator when the current player holds the enemy flag.
- `Solo.tsx`: `handleStartGame("ctf")` calls `gameManager.startCTFGame()` with a
  lobby notification; `handlePlayerPositionUpdate` now also calls
  `gameManager.pickupFlag`/`captureFlag` each frame while a CTF game is active, with
  success notifications ("You grabbed the enemy flag!" / "Flag captured!").
- Regression tests in `GameUI.test.tsx`: "Start CTF" lobby button click, and a new
  test asserting the team/score/carrying-flag HUD renders correctly.
- Roadmap doc updated: Phase D gameplay wiring marked done; remaining work is bot AI
  for CTF (pickup/capture/defend), which is the next follow-up.

## Test plan

- [x] `npm run typecheck` (Docker) — passes
- [x] `npm run lint -- --max-warnings=0` (Docker) — passes
- [x] Full suite (Docker): 426 passed / 5 skipped / 67 files (up from 425/5/67)
- [x] Pre-push hook re-ran the full suite — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)