### PR TITLE
Phase D part 3: bot AI for CTF (chase, capture, defend)

### DIFF
--- a/docs/MULTIPLAYER_SHOOTER_ROADMAP.md
+++ b/docs/MULTIPLAYER_SHOOTER_ROADMAP.md
@@ -2,9 +2,10 @@
 
 **Status:** Phase 1 (tag stabilization) complete. Phase A (pluggable game modes)
 complete. Phase B (combat primitives) complete. Phase C (deathmatch) complete end to
-end — backend, gameplay wiring, and bot combat AI. Phase D (CTF) backend and gameplay
-wiring (`CTFMode`, flags, teams, pickup/capture, Solo "Start CTF", team/flag HUD) are
-implemented — bot AI for CTF is next.
+end — backend, gameplay wiring, and bot combat AI. Phase D (CTF) is now complete end to
+end — backend (`CTFMode`, flags, teams, pickup/capture), gameplay wiring (Solo "Start
+CTF", team/flag HUD), and bot AI (chase/pickup/capture/defend). Phase E (polish) is
+next.
 
 ## Context
 
@@ -134,16 +135,21 @@ results, gameplay wiring, and bot fire behavior all pass (`gameManager.deathmatc
   team scores (`gameState.scores["a"]`/`["b"]`), a "carrying flag" indicator, and
   proximity-based pickup/capture (`GameManager.pickupFlag`/`captureFlag` called from
   `Solo.tsx`'s per-frame position sync).
-- **Remaining — bot AI** (follow-up PR, mirrors Phase C's split): bots currently stand
-  idle during CTF; add pickup/capture/defend behavior to `useBotAI` (e.g. chase the
-  enemy flag when unguarded, return to base when carrying, defend the home flag
-  otherwise).
+- ✅ **Bot AI**: `useBotAI` gained a CTF branch — bots on a team head to the enemy
+  flag while it's unguarded, carry it home (`captureFlag`) once picked up, and
+  otherwise hold/return to their own base to defend it. `Bots.tsx` threads
+  `team`/`isCarryingFlag` from `gameManager.getPlayers()`/`gameState.flags` down to
+  `BotCharacter`, and `Solo.tsx`'s per-frame bot position handlers call
+  `pickupFlag`/`captureFlag` for bots the same way they do for the player.
 
 **Acceptance:** ✅ `gameManager.ctf.test.ts` covers team assignment, flag spawning,
 pickup (including the "can't capture your own team's flag" edge case via the
 pickup-rejection check), range gating, flag-follows-carrier, capture/score/return,
 carrier-disconnect, and end-of-game team-score results. ✅ `GameUI.test.tsx` covers the
-"Start CTF" lobby button and the team/score/carrying-flag HUD.
+"Start CTF" lobby button and the team/score/carrying-flag HUD. ✅ `useBotAI.unit.test.tsx`
+and `Bots.test.tsx` cover CTF bot movement (chase unguarded flag, return when carrying,
+defend base when enemy flag is guarded, hold at destination) and prop wiring
+(`team`/`isCarryingFlag`).
 
 ---
 

--- a/src/__tests__/useBotAI.unit.test.tsx
+++ b/src/__tests__/useBotAI.unit.test.tsx
@@ -43,12 +43,20 @@ type HarnessProps = {
   onTagTarget: () => void;
   onFireAtTarget?: () => void;
   isDowned?: boolean;
+  team?: "a" | "b";
+  isCarryingFlag?: boolean;
   onPositionUpdate: (position: [number, number, number]) => void;
   gameState: {
-    mode: "tag" | "deathmatch" | "none";
+    mode: "tag" | "deathmatch" | "ctf" | "none";
     isActive: boolean;
     timeRemaining: number;
     scores: Record<string, number>;
+    flags?: {
+      team: "a" | "b";
+      position: [number, number, number];
+      basePosition: [number, number, number];
+      carrierId?: string;
+    }[];
   };
   collisionSystem: React.RefObject<CollisionSystem>;
   gotTaggedTimestamp?: number;
@@ -131,6 +139,22 @@ const deathmatchState = {
   timeRemaining: 120,
   scores: {},
 };
+
+const TEAM_A_BASE: [number, number, number] = [-15, 0.5, 0];
+const TEAM_B_BASE: [number, number, number] = [15, 0.5, 0];
+
+const ctfState = (
+  flags: HarnessProps["gameState"]["flags"] = [
+    { team: "a", position: TEAM_A_BASE, basePosition: TEAM_A_BASE },
+    { team: "b", position: TEAM_B_BASE, basePosition: TEAM_B_BASE },
+  ],
+) => ({
+  mode: "ctf" as const,
+  isActive: true,
+  timeRemaining: 180,
+  scores: { a: 0, b: 0 },
+  flags,
+});
 
 describe("useBotAI", () => {
   beforeEach(() => {
@@ -351,5 +375,92 @@ describe("useBotAI", () => {
     expect(meshRef.current.position.x).toBeCloseTo(before.x);
     expect(meshRef.current.position.z).toBeCloseTo(before.z);
     expect(onPositionUpdate).not.toHaveBeenCalled();
+  });
+
+  it("moves toward the unguarded enemy flag in CTF", () => {
+    vi.spyOn(Date, "now").mockReturnValue(5000);
+
+    const { meshRef } = mountHook({
+      isIt: false,
+      targetIsIt: false,
+      team: "a",
+      isCarryingFlag: false,
+      gameState: ctfState(),
+    });
+
+    // Team b's (enemy) flag sits at TEAM_B_BASE, +x of the bot's start.
+    frameCallback!(null, 1);
+
+    expect(meshRef.current.position.x).toBeGreaterThan(0);
+  });
+
+  it("heads to its own base when carrying the enemy flag in CTF", () => {
+    vi.spyOn(Date, "now").mockReturnValue(5000);
+
+    const { meshRef } = mountHook({
+      isIt: false,
+      targetIsIt: false,
+      team: "a",
+      isCarryingFlag: true,
+      gameState: ctfState(),
+    });
+
+    // Team a's own base sits at TEAM_A_BASE, -x of the bot's start.
+    frameCallback!(null, 1);
+
+    expect(meshRef.current.position.x).toBeLessThan(0);
+  });
+
+  it("holds position near its own base when the enemy flag is guarded in CTF", () => {
+    vi.spyOn(Date, "now").mockReturnValue(5000);
+
+    const { meshRef } = mountHook({
+      isIt: false,
+      targetIsIt: false,
+      team: "a",
+      isCarryingFlag: false,
+      gameState: ctfState([
+        { team: "a", position: TEAM_A_BASE, basePosition: TEAM_A_BASE },
+        {
+          team: "b",
+          position: [1, 0.5, 0],
+          basePosition: TEAM_B_BASE,
+          carrierId: "enemy-1",
+        },
+      ]),
+    });
+
+    // Enemy flag is carried, so the bot defends by returning to its own
+    // base (TEAM_A_BASE, -x of the bot's start) instead of chasing it.
+    frameCallback!(null, 1);
+
+    expect(meshRef.current.position.x).toBeLessThan(0);
+  });
+
+  it("doesn't move once it has reached its CTF destination", () => {
+    vi.spyOn(Date, "now").mockReturnValue(5000);
+
+    const { meshRef } = mountHook({
+      isIt: false,
+      targetIsIt: false,
+      team: "a",
+      isCarryingFlag: false,
+      gameState: ctfState([
+        { team: "a", position: [0, 0, 0], basePosition: [0, 0, 0] },
+        {
+          team: "b",
+          position: TEAM_B_BASE,
+          basePosition: TEAM_B_BASE,
+          carrierId: "enemy-1",
+        },
+      ]),
+    });
+
+    // Enemy flag is guarded, and the bot is already sitting on its own
+    // base (also at the origin) - it should stay put.
+    frameCallback!(null, 1);
+
+    expect(meshRef.current.position.x).toBe(0);
+    expect(meshRef.current.position.z).toBe(0);
   });
 });

--- a/src/components/characters/BotCharacter.tsx
+++ b/src/components/characters/BotCharacter.tsx
@@ -23,6 +23,10 @@ export interface BotCharacterProps {
   onFireAtTarget?: () => void;
   /** True while the bot is eliminated and awaiting respawn (deathmatch). */
   isDowned?: boolean;
+  /** This bot's team assignment (CTF). */
+  team?: "a" | "b";
+  /** True while this bot is carrying the enemy flag (CTF). */
+  isCarryingFlag?: boolean;
   gameState: GameState;
   collisionSystem: React.RefObject<CollisionSystem | null>;
   gotTaggedTimestamp?: number;
@@ -45,6 +49,8 @@ export const BotCharacter: React.FC<BotCharacterProps> = ({
   onTagTarget,
   onFireAtTarget,
   isDowned,
+  team,
+  isCarryingFlag,
   gameState,
   collisionSystem,
   gotTaggedTimestamp,
@@ -73,6 +79,8 @@ export const BotCharacter: React.FC<BotCharacterProps> = ({
     onTagTarget,
     onFireAtTarget,
     isDowned,
+    team,
+    isCarryingFlag,
     onPositionUpdate,
     gameState,
     collisionSystem,

--- a/src/components/characters/useBotAI.ts
+++ b/src/components/characters/useBotAI.ts
@@ -52,6 +52,10 @@ export interface BotAIProps {
   onFireAtTarget?: () => void;
   /** True while the bot is eliminated and awaiting respawn (deathmatch). */
   isDowned?: boolean;
+  /** This bot's team assignment (CTF). */
+  team?: "a" | "b";
+  /** True while this bot is carrying the enemy flag (CTF). */
+  isCarryingFlag?: boolean;
   onPositionUpdate: (position: [number, number, number]) => void;
   gameState: GameState;
   collisionSystem: React.RefObject<CollisionSystem | null>;
@@ -78,6 +82,8 @@ export function useBotAI({
   onTagTarget,
   onFireAtTarget,
   isDowned,
+  team,
+  isCarryingFlag,
   onPositionUpdate,
   gameState,
   collisionSystem,
@@ -305,6 +311,52 @@ export function useBotAI({
         // cooldown gate, so just retry on a short interval.
         lastFireTime.current = now;
         onFireAtTarget?.();
+      }
+    } else if (gameState.isActive && gameState.mode === "ctf" && team) {
+      // Carrying the enemy flag - head home to capture it. Otherwise grab
+      // the enemy flag while it's unguarded, or hold position at our own
+      // base to defend it.
+      const flags = gameState.flags ?? [];
+      const myFlag = flags.find((f) => f.team === team);
+      const enemyFlag = flags.find((f) => f.team !== team);
+
+      const destination =
+        isCarryingFlag && myFlag
+          ? myFlag.basePosition
+          : enemyFlag && enemyFlag.carrierId === undefined
+            ? enemyFlag.position
+            : myFlag?.basePosition;
+
+      if (destination) {
+        const destPos = new THREE.Vector3(...destination);
+
+        if (botPos.distanceTo(destPos) > 0.5) {
+          const direction = new THREE.Vector3()
+            .subVectors(destPos, botPos)
+            .normalize();
+
+          const currentPos = new THREE.Vector3(botPos.x, botPos.y, botPos.z);
+          const newPos = new THREE.Vector3(
+            botPos.x + direction.x * config.botSpeed * delta,
+            botPos.y,
+            botPos.z + direction.z * config.botSpeed * delta,
+          );
+
+          if (collisionSystem.current) {
+            const resolved = collisionSystem.current.checkCollision(
+              currentPos,
+              newPos,
+            );
+            botPos.x = resolved.x;
+            botPos.z = resolved.z;
+          } else {
+            botPos.x = newPos.x;
+            botPos.z = newPos.z;
+          }
+
+          const angle = Math.atan2(direction.x, direction.z);
+          meshRef.current.rotation.y = angle;
+        }
       }
     }
 

--- a/src/pages/Solo.tsx
+++ b/src/pages/Solo.tsx
@@ -444,8 +444,16 @@ const Solo: React.FC = () => {
       // Update clients ref so PlayerCharacter can detect bot for tagging (no re-render)
       clientsRef.current["bot-1"] = { position, rotation: ZERO_ROTATION };
       gameManager.current?.updatePlayerPosition("bot-1", position);
+
+      // CTFMode rejects these outside an active CTF game, so it's safe to
+      // call unconditionally every frame.
+      if (gameManager.current?.pickupFlag("bot-1")) {
+        addNotification("Bot1 grabbed a flag!", "warning");
+      } else if (gameManager.current?.captureFlag("bot-1")) {
+        addNotification("Bot1 captured a flag for their team!", "warning");
+      }
     },
-    [],
+    [addNotification],
   );
 
   const handleBot2PositionUpdate = useCallback(
@@ -454,8 +462,14 @@ const Solo: React.FC = () => {
       // Update clients ref so PlayerCharacter can detect bot for tagging (no re-render)
       clientsRef.current["bot-2"] = { position, rotation: ZERO_ROTATION };
       gameManager.current?.updatePlayerPosition("bot-2", position);
+
+      if (gameManager.current?.pickupFlag("bot-2")) {
+        addNotification("Bot2 grabbed a flag!", "warning");
+      } else if (gameManager.current?.captureFlag("bot-2")) {
+        addNotification("Bot2 captured a flag for their team!", "warning");
+      }
     },
-    [],
+    [addNotification],
   );
 
   // Bot debug mode auto-restart when game ends

--- a/src/pages/Solo/components/Bots.tsx
+++ b/src/pages/Solo/components/Bots.tsx
@@ -84,6 +84,13 @@ const Bots: React.FC<
     gameManager?.getPlayers().get("bot-1")?.respawnAt !== undefined;
   const bot2IsDowned =
     gameManager?.getPlayers().get("bot-2")?.respawnAt !== undefined;
+  // Team assignment and carried-flag status for CTF
+  const bot1Team = gameManager?.getPlayers().get("bot-1")?.team;
+  const bot2Team = gameManager?.getPlayers().get("bot-2")?.team;
+  const bot1CarryingFlag =
+    gameState.flags?.some((flag) => flag.carrierId === "bot-1") ?? false;
+  const bot2CarryingFlag =
+    gameState.flags?.some((flag) => flag.carrierId === "bot-2") ?? false;
   // Derive player isIt from gameManager to avoid stale React-state race windows
   const playerIsItFromManager =
     gameManager?.getPlayers().get(currentPlayerId)?.isIt ?? playerIsIt;
@@ -235,6 +242,8 @@ const Bots: React.FC<
         }}
         onFireAtTarget={handleBot1FireAtTarget}
         isDowned={bot1IsDowned}
+        team={bot1Team}
+        isCarryingFlag={bot1CarryingFlag}
         onPositionUpdate={handleBot1PositionUpdate}
         gameState={gameState}
         collisionSystem={collisionSystemRef}
@@ -252,6 +261,8 @@ const Bots: React.FC<
           onTagTarget={handleBot2TagTarget}
           onFireAtTarget={handleBot2FireAtTarget}
           isDowned={bot2IsDowned}
+          team={bot2Team}
+          isCarryingFlag={bot2CarryingFlag}
           onPositionUpdate={handleBot2PositionUpdate}
           gameState={gameState}
           collisionSystem={collisionSystemRef}

--- a/src/pages/Solo/components/__tests__/Bots.test.tsx
+++ b/src/pages/Solo/components/__tests__/Bots.test.tsx
@@ -240,6 +240,38 @@ describe("Bots", () => {
     expect(botPropsByRender[0].isDowned).toBe(true);
   });
 
+  it("passes team assignment and carried-flag status to bots during CTF", () => {
+    vi.spyOn(Date, "now").mockReturnValue(5000);
+
+    const gm = new GameManager();
+    gm.addPlayer(makeBotPlayer("bot-1", "Bot1"));
+    gm.addPlayer(makeBotPlayer("bot-2", "Bot2"));
+    gm.addPlayer(makeBotPlayer("player-1", "Player1"));
+    gm.startCTFGame();
+
+    // Mark bot-1 as carrying the enemy team's flag.
+    const flags = gm.getGameState().flags!;
+    const enemyFlag = flags.find(
+      (f) => f.team !== gm.getPlayers().get("bot-1")?.team,
+    )!;
+    enemyFlag.carrierId = "bot-1";
+
+    const props = buildProps({
+      botDebugMode: true,
+      gameManager: gm as unknown as React.ComponentProps<
+        typeof Bots
+      >["gameManager"],
+      gameState: gm.getGameState(),
+    });
+
+    render(<Bots {...props} />);
+
+    expect(botPropsByRender[0].team).toBe(gm.getPlayers().get("bot-1")?.team);
+    expect(botPropsByRender[0].isCarryingFlag).toBe(true);
+    expect(botPropsByRender[1].team).toBe(gm.getPlayers().get("bot-2")?.team);
+    expect(botPropsByRender[1].isCarryingFlag).toBe(false);
+  });
+
   it("allows bot-2 to tag bot-1 when bot-2 is IT", () => {
     const setBot1GotTagged = vi.fn();
     const players = new Map<string, { isIt: boolean }>([


### PR DESCRIPTION
## Summary
- `useBotAI` gains a `\"ctf\"` mode branch: bots on a team head to the enemy team's unguarded flag, carry it home (triggering `captureFlag`) once picked up, and otherwise hold/return to their own base to defend it (mirrors the deathmatch bot AI added in #243).
- `Bots.tsx` derives `team`/`isCarryingFlag` from `gameManager.getPlayers()`/`gameState.flags` and threads them through `BotCharacter` into `useBotAI`.
- `Solo.tsx`'s per-frame bot position handlers (`handleBot1PositionUpdate`/`handleBot2PositionUpdate`) now call `pickupFlag`/`captureFlag` for bots, same as the player wiring from #245 (these are safe to call unconditionally - `CTFMode` rejects them outside an active CTF game).
- Updated `docs/MULTIPLAYER_SHOOTER_ROADMAP.md`: Phase D (CTF) is now complete end to end (backend + gameplay wiring + bot AI). Phase E (polish) is next.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint -- --max-warnings=0` passes
- [x] Full suite: 431 passed / 5 skipped (67 files) - up from 426/5/67
- [x] New `useBotAI.unit.test.tsx` cases: bot chases unguarded enemy flag, heads to base when carrying the enemy flag, defends base when enemy flag is guarded, holds position once at its CTF destination
- [x] New `Bots.test.tsx` case: `team`/`isCarryingFlag` props correctly passed to `BotCharacter` during a live CTF game

🤖 Generated with [Claude Code](https://claude.com/claude-code)