### PR TITLE
Phase D+: CTF combat - health, damage, respawn, and bot guns

### DIFF
--- a/docs/MULTIPLAYER_SHOOTER_ROADMAP.md
+++ b/docs/MULTIPLAYER_SHOOTER_ROADMAP.md
@@ -4,8 +4,9 @@
 complete. Phase B (combat primitives) complete. Phase C (deathmatch) complete end to
 end — backend, gameplay wiring, and bot combat AI. Phase D (CTF) is now complete end to
 end — backend (`CTFMode`, flags, teams, pickup/capture), gameplay wiring (Solo "Start
-CTF", team/flag HUD), and bot AI (chase/pickup/capture/defend). Phase E (polish) is
-next.
+CTF", team/flag HUD), bot AI (chase/pickup/capture/defend), and CTF combat
+(health/damage/respawn, flag-drop-on-death, bots fire at enemies in range without
+abandoning their flag objective). Phase E (polish) is next.
 
 ## Context
 
@@ -141,15 +142,29 @@ results, gameplay wiring, and bot fire behavior all pass (`gameManager.deathmatc
   `team`/`isCarryingFlag` from `gameManager.getPlayers()`/`gameState.flags` down to
   `BotCharacter`, and `Solo.tsx`'s per-frame bot position handlers call
   `pickupFlag`/`captureFlag` for bots the same way they do for the player.
+- ✅ **CTF combat ("bots with guns")**: `CTFMode` now initializes
+  `health`/`maxHealth`/`respawnAt` on start (mirroring `DeathmatchMode`) and handles
+  `onAction({ type: "hit", ... })` — damage reduces health, a lethal hit starts a
+  respawn timer and drops any flag the target was carrying back to its base, and
+  `onTick` restores health/clears `respawnAt` once the respawn delay elapses. No
+  kill-score is tracked for CTF (capture remains the only scoring mechanism).
+  `GameManager.hitPlayer` and `usePlayerWeapon.processFiring` now allow `mode ===
+"ctf"`. `useBotAI`'s CTF branch gained a `targetTeam` prop — bots fire at enemies
+  (never allies) within `FIRE_RANGE` opportunistically, without abandoning their
+  flag-objective movement, and sit out (pulsing) while downed like in deathmatch.
+  `GameUI`'s CTF HUD gained a health indicator alongside the team/score display.
 
 **Acceptance:** ✅ `gameManager.ctf.test.ts` covers team assignment, flag spawning,
 pickup (including the "can't capture your own team's flag" edge case via the
 pickup-rejection check), range gating, flag-follows-carrier, capture/score/return,
-carrier-disconnect, and end-of-game team-score results. ✅ `GameUI.test.tsx` covers the
-"Start CTF" lobby button and the team/score/carrying-flag HUD. ✅ `useBotAI.unit.test.tsx`
-and `Bots.test.tsx` cover CTF bot movement (chase unguarded flag, return when carrying,
-defend base when enemy flag is guarded, hold at destination) and prop wiring
-(`team`/`isCarryingFlag`).
+carrier-disconnect, end-of-game team-score results, and combat (health init, damage,
+lethal hit → respawn + flag drop, respawn restoration, rejecting hits on downed/inactive
+players). ✅ `GameUI.test.tsx` covers the "Start CTF" lobby button and the
+team/score/health/carrying-flag HUD. ✅ `useBotAI.unit.test.tsx` and `Bots.test.tsx`
+cover CTF bot movement (chase unguarded flag, return when carrying, defend base when
+enemy flag is guarded, hold at destination), combat (fire at enemy in range, no
+friendly fire, range gating, sit out while downed), and prop wiring
+(`team`/`isCarryingFlag`/`targetTeam`).
 
 ---
 

--- a/src/__tests__/gameManager.ctf.test.ts
+++ b/src/__tests__/gameManager.ctf.test.ts
@@ -165,6 +165,97 @@ describe("GameManager CTF", () => {
     expect(flagB.position).toEqual(TEAM_B_BASE);
   });
 
+  it("starting CTF initializes health and maxHealth for all players", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+    manager.startCTFGame();
+
+    for (const player of manager.getPlayers().values()) {
+      expect(player.health).toBe(100);
+      expect(player.maxHealth).toBe(100);
+    }
+  });
+
+  it("a hit during CTF reduces the target's health without affecting team scores", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+    manager.startCTFGame();
+
+    expect(manager.hitPlayer("p1", "p2", 30)).toBe(true);
+    expect(manager.getPlayers().get("p2")?.health).toBe(70);
+    expect(manager.getGameState().scores).toEqual({ a: 0, b: 0 });
+  });
+
+  it("a lethal hit downs the target, starts a respawn timer, and drops their carried flag", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1")); // team a
+    manager.addPlayer(makePlayer("p2", "P2", TEAM_A_BASE)); // team b, picks up team a's flag
+
+    vi.spyOn(Date, "now").mockReturnValue(10000);
+    manager.startCTFGame();
+    manager.pickupFlag("p2");
+    expect(
+      manager.getGameState().flags!.find((f) => f.team === "a")?.carrierId,
+    ).toBe("p2");
+
+    expect(manager.hitPlayer("p1", "p2", 1000)).toBe(true);
+
+    const target = manager.getPlayers().get("p2")!;
+    expect(target.health).toBe(0);
+    expect(target.respawnAt).toBe(13000);
+
+    const flagA = manager.getGameState().flags!.find((f) => f.team === "a")!;
+    expect(flagA.carrierId).toBeUndefined();
+    expect(flagA.position).toEqual(TEAM_A_BASE);
+  });
+
+  it("restores health and clears respawnAt once the CTF respawn delay elapses", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+
+    vi.spyOn(Date, "now").mockReturnValue(10000);
+    manager.startCTFGame();
+    manager.hitPlayer("p1", "p2", 1000);
+
+    const target = manager.getPlayers().get("p2")!;
+    expect(target.health).toBe(0);
+    expect(target.respawnAt).toBe(13000);
+
+    vi.spyOn(Date, "now").mockReturnValue(13001);
+    manager.updateGameTimer(0.1);
+
+    expect(target.health).toBe(target.maxHealth);
+    expect(target.respawnAt).toBeUndefined();
+  });
+
+  it("rejects hits on a player who is awaiting respawn in CTF", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+
+    vi.spyOn(Date, "now").mockReturnValue(10000);
+    manager.startCTFGame();
+    manager.hitPlayer("p1", "p2", 1000); // p2 downed, awaiting respawn
+
+    expect(manager.hitPlayer("p1", "p2", 10)).toBe(false);
+  });
+
+  it("rejects hits outside an active CTF game", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+
+    // Not started yet
+    expect(manager.hitPlayer("p1", "p2", 10)).toBe(false);
+
+    // Started in tag mode instead
+    manager.startTagGame();
+    expect(manager.hitPlayer("p1", "p2", 10)).toBe(false);
+  });
+
   it("ends the game with results based on each player's team score", () => {
     const manager = new GameManager();
     manager.addPlayer(makePlayer("p1", "P1", TEAM_B_BASE)); // team a

--- a/src/__tests__/useBotAI.unit.test.tsx
+++ b/src/__tests__/useBotAI.unit.test.tsx
@@ -44,6 +44,7 @@ type HarnessProps = {
   onFireAtTarget?: () => void;
   isDowned?: boolean;
   team?: "a" | "b";
+  targetTeam?: "a" | "b";
   isCarryingFlag?: boolean;
   onPositionUpdate: (position: [number, number, number]) => void;
   gameState: {
@@ -435,6 +436,79 @@ describe("useBotAI", () => {
     frameCallback!(null, 1);
 
     expect(meshRef.current.position.x).toBeLessThan(0);
+  });
+
+  it("fires at an enemy within range during CTF", () => {
+    vi.spyOn(Date, "now").mockReturnValue(5000);
+
+    const { onFireAtTarget } = mountHook({
+      isIt: false,
+      targetIsIt: false,
+      team: "a",
+      targetTeam: "b",
+      gameState: ctfState(),
+      targetPositionRef: { current: [5, 0, 0] }, // within FIRE_RANGE (10)
+    });
+
+    frameCallback!(null, 0.016);
+
+    expect(onFireAtTarget).toHaveBeenCalledTimes(1);
+  });
+
+  it("doesn't fire on an ally during CTF, even within range", () => {
+    vi.spyOn(Date, "now").mockReturnValue(5000);
+
+    const { onFireAtTarget } = mountHook({
+      isIt: false,
+      targetIsIt: false,
+      team: "a",
+      targetTeam: "a",
+      gameState: ctfState(),
+      targetPositionRef: { current: [5, 0, 0] },
+    });
+
+    frameCallback!(null, 0.016);
+
+    expect(onFireAtTarget).not.toHaveBeenCalled();
+  });
+
+  it("doesn't fire on an enemy beyond fire range during CTF", () => {
+    vi.spyOn(Date, "now").mockReturnValue(5000);
+
+    const { onFireAtTarget } = mountHook({
+      isIt: false,
+      targetIsIt: false,
+      team: "a",
+      targetTeam: "b",
+      gameState: ctfState(),
+      targetPositionRef: { current: [20, 0, 0] }, // beyond FIRE_RANGE (10)
+    });
+
+    frameCallback!(null, 0.016);
+
+    expect(onFireAtTarget).not.toHaveBeenCalled();
+  });
+
+  it("neither moves nor fires while downed in CTF", () => {
+    vi.spyOn(Date, "now").mockReturnValue(5000);
+
+    const { meshRef, onFireAtTarget, onPositionUpdate } = mountHook({
+      isIt: false,
+      targetIsIt: false,
+      team: "a",
+      isDowned: true,
+      targetTeam: "b",
+      gameState: ctfState(),
+      targetPositionRef: { current: [5, 0, 0] },
+    });
+
+    frameCallback!(null, 1);
+
+    expect(meshRef.current.position.x).toBe(0);
+    expect(onFireAtTarget).not.toHaveBeenCalled();
+    expect(onPositionUpdate).not.toHaveBeenCalled();
+    // Downed bots pulse in place as a visual cue.
+    expect(meshRef.current.scale.set).toHaveBeenCalled();
   });
 
   it("doesn't move once it has reached its CTF destination", () => {

--- a/src/components/GameManager.ts
+++ b/src/components/GameManager.ts
@@ -209,7 +209,10 @@ export class GameManager {
   }
 
   hitPlayer(attackerId: string, targetId: string, damage: number): boolean {
-    if (this.gameState.mode !== "deathmatch" || !this.gameState.isActive) {
+    if (
+      (this.gameState.mode !== "deathmatch" && this.gameState.mode !== "ctf") ||
+      !this.gameState.isActive
+    ) {
       return false;
     }
 

--- a/src/components/GameUI.tsx
+++ b/src/components/GameUI.tsx
@@ -197,6 +197,20 @@ const GameUI: React.FC<GameUIProps> = ({
               {currentPlayer?.team === "a" ? "🔵 Team A" : "🔴 Team B"}
             </div>
 
+            <div
+              style={{
+                marginBottom: isMinimal ? "2px" : "6px",
+                padding: isMinimal ? "2px 3px" : "4px 8px",
+                backgroundColor: "rgba(100, 255, 100, 0.2)",
+                borderRadius: "3px",
+                border: "1px solid #64ff64",
+                fontSize: isMinimal ? "8px" : isMobile ? "10px" : "11px",
+              }}
+            >
+              ❤️ {currentPlayer?.health ?? currentPlayer?.maxHealth ?? 100}
+              {!isMinimal && ` / ${currentPlayer?.maxHealth ?? 100}`}
+            </div>
+
             {!isMinimal && (
               <div
                 style={{

--- a/src/components/characters/BotCharacter.tsx
+++ b/src/components/characters/BotCharacter.tsx
@@ -27,6 +27,8 @@ export interface BotCharacterProps {
   team?: "a" | "b";
   /** True while this bot is carrying the enemy flag (CTF). */
   isCarryingFlag?: boolean;
+  /** The target's team assignment (CTF) - used to avoid friendly fire. */
+  targetTeam?: "a" | "b";
   gameState: GameState;
   collisionSystem: React.RefObject<CollisionSystem | null>;
   gotTaggedTimestamp?: number;
@@ -51,6 +53,7 @@ export const BotCharacter: React.FC<BotCharacterProps> = ({
   isDowned,
   team,
   isCarryingFlag,
+  targetTeam,
   gameState,
   collisionSystem,
   gotTaggedTimestamp,
@@ -81,6 +84,7 @@ export const BotCharacter: React.FC<BotCharacterProps> = ({
     isDowned,
     team,
     isCarryingFlag,
+    targetTeam,
     onPositionUpdate,
     gameState,
     collisionSystem,

--- a/src/components/characters/useBotAI.ts
+++ b/src/components/characters/useBotAI.ts
@@ -56,6 +56,8 @@ export interface BotAIProps {
   team?: "a" | "b";
   /** True while this bot is carrying the enemy flag (CTF). */
   isCarryingFlag?: boolean;
+  /** The target's team assignment (CTF) - used to avoid friendly fire. */
+  targetTeam?: "a" | "b";
   onPositionUpdate: (position: [number, number, number]) => void;
   gameState: GameState;
   collisionSystem: React.RefObject<CollisionSystem | null>;
@@ -84,6 +86,7 @@ export function useBotAI({
   isDowned,
   team,
   isCarryingFlag,
+  targetTeam,
   onPositionUpdate,
   gameState,
   collisionSystem,
@@ -313,6 +316,25 @@ export function useBotAI({
         onFireAtTarget?.();
       }
     } else if (gameState.isActive && gameState.mode === "ctf" && team) {
+      if (isDowned) {
+        // Eliminated and awaiting respawn - pulse in place and sit out.
+        const pulse = 1 + Math.sin(now * 0.01) * 0.1;
+        meshRef.current.scale.set(pulse, pulse, pulse);
+        return;
+      }
+
+      // Engage an enemy within fire range while pursuing the flag
+      // objective below - CTF combat doesn't pause movement to shoot.
+      if (
+        targetTeam !== undefined &&
+        targetTeam !== team &&
+        distance <= FIRE_RANGE &&
+        now - lastFireTime.current > FIRE_RETRY_INTERVAL_MS
+      ) {
+        lastFireTime.current = now;
+        onFireAtTarget?.();
+      }
+
       // Carrying the enemy flag - head home to capture it. Otherwise grab
       // the enemy flag while it's unguarded, or hold position at our own
       // base to defend it.

--- a/src/components/gameModes/CTFMode.ts
+++ b/src/components/gameModes/CTFMode.ts
@@ -27,11 +27,16 @@ function distance(
  * Capture-the-flag rules: players alternate onto team "a"/"b" at the start
  * of the round, each defending a flag at their team's base. Picking up the
  * enemy flag and carrying it back to your own base scores a point for your
- * team and returns the flag to its base.
+ * team and returns the flag to its base. Weapon hits (Phase B) are also
+ * live: a downed player drops any flag they're carrying and sits out for a
+ * brief respawn delay, mirroring DeathmatchMode but without kill scoring -
+ * only flag captures count toward gameState.scores.
  */
 export class CTFMode implements GameModeHandler {
   private readonly PICKUP_RADIUS = 1.5;
   private readonly CAPTURE_RADIUS = 2;
+  private readonly DEFAULT_MAX_HEALTH = 100;
+  private readonly RESPAWN_DELAY_MS = 3000;
 
   onStart(players: Map<string, Player>, gameState: GameState): void {
     gameState.scores = { a: 0, b: 0 };
@@ -43,6 +48,9 @@ export class CTFMode implements GameModeHandler {
     let i = 0;
     players.forEach((player) => {
       player.team = i % 2 === 0 ? "a" : "b";
+      player.maxHealth = player.maxHealth ?? this.DEFAULT_MAX_HEALTH;
+      player.health = player.maxHealth;
+      player.respawnAt = undefined;
       i++;
     });
   }
@@ -60,6 +68,14 @@ export class CTFMode implements GameModeHandler {
       const carrier = players.get(flag.carrierId);
       if (carrier) flag.position = carrier.position;
     });
+
+    const now = Date.now();
+    players.forEach((player) => {
+      if (player.respawnAt !== undefined && now >= player.respawnAt) {
+        player.health = player.maxHealth ?? this.DEFAULT_MAX_HEALTH;
+        player.respawnAt = undefined;
+      }
+    });
   }
 
   onAction(
@@ -73,7 +89,47 @@ export class CTFMode implements GameModeHandler {
     if (action.type === "captureFlag") {
       return this.captureFlag(action.playerId, players, gameState);
     }
+    if (action.type === "hit") {
+      return this.hit(action, players, gameState);
+    }
     return false;
+  }
+
+  private hit(
+    action: { attackerId: string; targetId: string; damage: number },
+    players: Map<string, Player>,
+    gameState: GameState,
+  ): boolean {
+    const { attackerId, targetId, damage } = action;
+    if (attackerId === targetId) return false;
+
+    const attacker = players.get(attackerId);
+    const target = players.get(targetId);
+    if (!attacker || !target) return false;
+
+    // A downed player awaiting respawn can't take further damage.
+    if (target.respawnAt !== undefined) return false;
+
+    const maxHealth = target.maxHealth ?? this.DEFAULT_MAX_HEALTH;
+    const currentHealth = target.health ?? maxHealth;
+    target.health = Math.max(0, currentHealth - damage);
+
+    if (target.health === 0) {
+      target.respawnAt = Date.now() + this.RESPAWN_DELAY_MS;
+
+      // A downed carrier drops the flag back at its base rather than
+      // letting it sit on a player who's now out of the round.
+      gameState.flags?.forEach((flag) => {
+        if (flag.carrierId === targetId) {
+          flag.carrierId = undefined;
+          flag.position = [...flag.basePosition];
+        }
+      });
+
+      log.debug(`${attacker.name} downed ${target.name}!`);
+    }
+
+    return true;
   }
 
   private pickupFlag(
@@ -154,6 +210,8 @@ export class CTFMode implements GameModeHandler {
 
     players.forEach((player) => {
       player.team = undefined;
+      player.health = player.maxHealth;
+      player.respawnAt = undefined;
     });
 
     return results;

--- a/src/lib/hooks/usePlayerWeapon.ts
+++ b/src/lib/hooks/usePlayerWeapon.ts
@@ -70,9 +70,13 @@ export function processFiring(params: FireParams): FireResult | null {
     const gameState = gameManager.getGameState();
     let damageApplied = false;
 
-    if (gameState.mode === "deathmatch" && gameState.isActive) {
-      // Deathmatch: DeathmatchMode applies damage, awards kills, and starts
-      // respawn timers. Rejected hits (e.g. a downed target) deal no damage.
+    if (
+      (gameState.mode === "deathmatch" || gameState.mode === "ctf") &&
+      gameState.isActive
+    ) {
+      // Deathmatch/CTF: the active mode applies damage and starts respawn
+      // timers (and, in CTF, drops any carried flag). Rejected hits (e.g. a
+      // downed target) deal no damage.
       damageApplied = gameManager.hitPlayer(
         shooterId,
         hit.hitPlayerId,

--- a/src/pages/Solo/components/Bots.tsx
+++ b/src/pages/Solo/components/Bots.tsx
@@ -91,6 +91,11 @@ const Bots: React.FC<
     gameState.flags?.some((flag) => flag.carrierId === "bot-1") ?? false;
   const bot2CarryingFlag =
     gameState.flags?.some((flag) => flag.carrierId === "bot-2") ?? false;
+  // Team of each bot's current target, so CTF combat doesn't fire on allies.
+  const bot1TargetTeam = botDebugMode
+    ? bot2Team
+    : gameManager?.getPlayers().get(currentPlayerId)?.team;
+  const bot2TargetTeam = bot1Team;
   // Derive player isIt from gameManager to avoid stale React-state race windows
   const playerIsItFromManager =
     gameManager?.getPlayers().get(currentPlayerId)?.isIt ?? playerIsIt;
@@ -179,7 +184,7 @@ const Bots: React.FC<
     (botId: string, targetId: string) => {
       if (
         !gameManager ||
-        gameState.mode !== "deathmatch" ||
+        (gameState.mode !== "deathmatch" && gameState.mode !== "ctf") ||
         !gameState.isActive
       ) {
         return;
@@ -244,6 +249,7 @@ const Bots: React.FC<
         isDowned={bot1IsDowned}
         team={bot1Team}
         isCarryingFlag={bot1CarryingFlag}
+        targetTeam={bot1TargetTeam}
         onPositionUpdate={handleBot1PositionUpdate}
         gameState={gameState}
         collisionSystem={collisionSystemRef}
@@ -263,6 +269,7 @@ const Bots: React.FC<
           isDowned={bot2IsDowned}
           team={bot2Team}
           isCarryingFlag={bot2CarryingFlag}
+          targetTeam={bot2TargetTeam}
           onPositionUpdate={handleBot2PositionUpdate}
           gameState={gameState}
           collisionSystem={collisionSystemRef}

--- a/src/pages/Solo/components/__tests__/Bots.test.tsx
+++ b/src/pages/Solo/components/__tests__/Bots.test.tsx
@@ -268,8 +268,38 @@ describe("Bots", () => {
 
     expect(botPropsByRender[0].team).toBe(gm.getPlayers().get("bot-1")?.team);
     expect(botPropsByRender[0].isCarryingFlag).toBe(true);
+    expect(botPropsByRender[0].targetTeam).toBe(
+      gm.getPlayers().get("bot-2")?.team,
+    );
     expect(botPropsByRender[1].team).toBe(gm.getPlayers().get("bot-2")?.team);
     expect(botPropsByRender[1].isCarryingFlag).toBe(false);
+    expect(botPropsByRender[1].targetTeam).toBe(
+      gm.getPlayers().get("bot-1")?.team,
+    );
+  });
+
+  it("routes bot laser fire through hitPlayer during CTF", () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(5000);
+
+    const gm = new GameManager();
+    gm.addPlayer(makeBotPlayer("bot-1", "Bot1"));
+    gm.addPlayer(makeBotPlayer("player-1", "Player1"));
+    gm.startCTFGame();
+
+    const props = buildProps({
+      gameManager: gm as unknown as React.ComponentProps<
+        typeof Bots
+      >["gameManager"],
+      gameState: gm.getGameState(),
+    });
+
+    render(<Bots {...props} />);
+    const fire = botPropsByRender[0].onFireAtTarget as () => void;
+
+    fire();
+    expect(gm.getPlayers().get("player-1")?.health).toBe(90);
+
+    nowSpy.mockRestore();
   });
 
   it("allows bot-2 to tag bot-1 when bot-2 is IT", () => {


### PR DESCRIPTION
## Summary
- `CTFMode` now mirrors `DeathmatchMode`'s health/maxHealth/respawn model: `onStart` initializes health, `onAction({type:"hit",...})` applies damage and starts a respawn timer on a lethal hit, and `onTick` restores health once the respawn delay elapses. No kill-score is tracked for CTF — capture remains the only scoring mechanism.
- A lethal hit drops any flag the downed player was carrying back to its base.
- `GameManager.hitPlayer` and `usePlayerWeapon.processFiring` now allow `mode === "ctf"` in addition to `"deathmatch"`.
- `useBotAI`'s CTF branch gained a `targetTeam` prop: bots fire at enemies (never allies) within `FIRE_RANGE` opportunistically without abandoning their flag-objective movement, and sit out (pulsing) while downed, same as deathmatch.
- `targetTeam` is threaded through `BotCharacter` and computed in `Bots.tsx` (each bot's target is the opposing team), and `fireBotLaser`'s mode gate now includes `"ctf"`.
- `GameUI`'s CTF HUD gains a health indicator alongside the team/score display.
- Updated `docs/MULTIPLAYER_SHOOTER_ROADMAP.md` to document CTF combat as part of Phase D.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint -- --max-warnings=0` passes
- [x] Full suite: 442 passed / 5 skipped / 67 files (up from 431/5/67)
- [x] New tests in `gameManager.ctf.test.ts`: health init on start, hit reduces health without affecting team scores, lethal hit downs+respawns+drops carried flag, respawn restoration, rejects hits on downed/inactive-CTF players
- [x] New tests in `useBotAI.unit.test.tsx`: fires at enemy in range during CTF, no friendly fire, range gating, sits out (no move/fire) while downed
- [x] New tests in `Bots.test.tsx`: `targetTeam` prop wiring, bot laser fire routes through `hitPlayer` during CTF

🤖 Generated with [Claude Code](https://claude.com/claude-code)