### PR TITLE
Phase E: Pulse Shotgun + weapon switching (1/2 keys)

### DIFF
--- a/src/__tests__/PlayerCharacter.frame.test.tsx
+++ b/src/__tests__/PlayerCharacter.frame.test.tsx
@@ -184,6 +184,7 @@ describe("PlayerCharacter frame behavior", () => {
               scores: {},
               timeRemaining: 10,
             }),
+            updatePlayer: vi.fn(),
           } as unknown as import("../components/GameManager").GameManager
         }
         currentPlayerId="socket-1"
@@ -248,6 +249,7 @@ describe("PlayerCharacter frame behavior", () => {
               scores: {},
               timeRemaining: 10,
             }),
+            updatePlayer: vi.fn(),
           } as unknown as import("../components/GameManager").GameManager
         }
         currentPlayerId="socket-1"
@@ -308,6 +310,7 @@ describe("PlayerCharacter frame behavior", () => {
               scores: {},
               timeRemaining: 10,
             }),
+            updatePlayer: vi.fn(),
           } as unknown as import("../components/GameManager").GameManager
         }
         currentPlayerId="socket-1"

--- a/src/__tests__/PlayerCharacter.handle.test.tsx
+++ b/src/__tests__/PlayerCharacter.handle.test.tsx
@@ -91,9 +91,11 @@ type FakeGameManager = {
   getGameState: () => { mode: string; isActive: boolean };
 };
 
-const fakeGameManager: FakeGameManager = {
+type FakeGameManagerWithUpdate = FakeGameManager & { updatePlayer: () => void };
+const fakeGameManager: FakeGameManagerWithUpdate = {
   getPlayers: () => new Map<unknown, unknown>(),
   getGameState: () => ({ mode: "tag", isActive: false }),
+  updatePlayer: vi.fn(),
 };
 
 describe("PlayerCharacter imperative handle", () => {
@@ -123,7 +125,7 @@ describe("PlayerCharacter imperative handle", () => {
           lastWalkSoundTimeRef={{ current: 0 }}
           isPaused={true}
         />
-      </div>
+      </div>,
     );
 
     // Should expose methods

--- a/src/components/GameManager.ts
+++ b/src/components/GameManager.ts
@@ -52,6 +52,8 @@ export interface Player {
   respawnAt?: number;
   /** Team assignment for capture-the-flag. */
   team?: "a" | "b";
+  /** Currently equipped weapon id (e.g. "laser", "shotgun"). */
+  equippedWeaponId?: string;
 }
 
 export class GameManager {

--- a/src/components/GameUI.tsx
+++ b/src/components/GameUI.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { GameState, Player } from "./GameManager";
+import { WEAPONS } from "./combat/WeaponManager";
 
 interface GameUIProps {
   gameState: GameState;
@@ -151,6 +152,21 @@ const GameUI: React.FC<GameUIProps> = ({
               {!isMinimal && ` / ${currentPlayer?.maxHealth ?? 100}`}
             </div>
 
+            {!isMinimal && currentPlayer?.equippedWeaponId && (
+              <div
+                style={{
+                  marginBottom: "6px",
+                  fontSize: isMobile ? "9px" : "10px",
+                  color: "#aaddff",
+                }}
+              >
+                🔫{" "}
+                {WEAPONS[currentPlayer.equippedWeaponId]?.name ??
+                  currentPlayer.equippedWeaponId}{" "}
+                [1/2]
+              </div>
+            )}
+
             {!isMinimal && (
               <div
                 style={{
@@ -210,6 +226,21 @@ const GameUI: React.FC<GameUIProps> = ({
               ❤️ {currentPlayer?.health ?? currentPlayer?.maxHealth ?? 100}
               {!isMinimal && ` / ${currentPlayer?.maxHealth ?? 100}`}
             </div>
+
+            {!isMinimal && currentPlayer?.equippedWeaponId && (
+              <div
+                style={{
+                  marginBottom: "6px",
+                  fontSize: isMobile ? "9px" : "10px",
+                  color: "#aaddff",
+                }}
+              >
+                🔫{" "}
+                {WEAPONS[currentPlayer.equippedWeaponId]?.name ??
+                  currentPlayer.equippedWeaponId}{" "}
+                [1/2]
+              </div>
+            )}
 
             {!isMinimal && (
               <div

--- a/src/components/__tests__/GameUI.test.tsx
+++ b/src/components/__tests__/GameUI.test.tsx
@@ -128,6 +128,62 @@ describe("GameUI", () => {
     expect(screen.getByText("💀 Player One: 2 / 10")).toBeInTheDocument();
   });
 
+  it("shows equipped weapon name in deathmatch HUD", () => {
+    const players = mkPlayers();
+    players.get("p1")!.health = 100;
+    players.get("p1")!.maxHealth = 100;
+    players.get("p1")!.equippedWeaponId = "shotgun";
+
+    const gameState: GameState = {
+      mode: "deathmatch",
+      isActive: true,
+      timeRemaining: 60,
+      scores: {},
+      killLimit: 10,
+      roundStartTime: Date.now(),
+    };
+
+    render(
+      <GameUI
+        gameState={gameState}
+        players={players}
+        currentPlayerId="p1"
+        onStartGame={vi.fn()}
+        onEndGame={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/Pulse Shotgun/)).toBeInTheDocument();
+  });
+
+  it("shows equipped weapon name in CTF HUD", () => {
+    const players = mkPlayers();
+    players.get("p1")!.team = "a";
+    players.get("p1")!.equippedWeaponId = "laser";
+    players.get("p2")!.team = "b";
+
+    const gameState: GameState = {
+      mode: "ctf",
+      isActive: true,
+      timeRemaining: 60,
+      scores: { a: 0, b: 0 },
+      roundStartTime: Date.now(),
+      flags: [],
+    };
+
+    render(
+      <GameUI
+        gameState={gameState}
+        players={players}
+        currentPlayerId="p1"
+        onStartGame={vi.fn()}
+        onEndGame={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/Laser Blaster/)).toBeInTheDocument();
+  });
+
   it("renders team, scores, and carried-flag status during an active CTF game", () => {
     const players = mkPlayers();
     players.get("p1")!.team = "a";

--- a/src/components/characters/PlayerCharacter.tsx
+++ b/src/components/characters/PlayerCharacter.tsx
@@ -5,7 +5,7 @@ import { Socket } from "socket.io-client";
 import * as THREE from "three";
 import type { Clients } from "../../types/socket";
 import GameManager, { GameState } from "../GameManager";
-import { W, A, S, D, Q, E, SHIFT, SPACE } from "../utils";
+import { W, A, S, D, Q, E, SHIFT, SPACE, KEY_1, KEY_2 } from "../utils";
 import SpacemanModel from "../SpacemanModel";
 import { getSoundManager } from "../SoundManager";
 import { WeaponManager } from "../combat/WeaponManager";
@@ -153,11 +153,16 @@ export const PlayerCharacter = React.forwardRef<
   const laserBeamRef = React.useRef<THREE.Group>(null);
   const laserBeamHideAtRef = React.useRef(0);
   const weaponManagerRef = React.useRef(new WeaponManager());
+  const prevKey1Ref = React.useRef(false);
+  const prevKey2Ref = React.useRef(false);
 
-  // Equip the laser blaster by default for the visible laser-fire mechanic.
+  // Equip the laser blaster by default and surface the equipped weapon to the HUD.
   React.useEffect(() => {
     weaponManagerRef.current.equip("laser");
-  }, []);
+    if (gameManager) {
+      gameManager.updatePlayer(currentPlayerId, { equippedWeaponId: "laser" });
+    }
+  }, [gameManager, currentPlayerId]);
 
   // Expose reset and freeze functions to parent via ref
   React.useImperativeHandle(ref, () => ({
@@ -377,7 +382,23 @@ export const PlayerCharacter = React.forwardRef<
       }
     }
 
-    // Fire the equipped laser while left-click is held (rate-limited by
+    // Weapon switching: rising-edge detection for 1 (laser) and 2 (shotgun).
+    const key1 = keysPressedRef.current[KEY_1] ?? false;
+    const key2 = keysPressedRef.current[KEY_2] ?? false;
+    if (key1 && !prevKey1Ref.current) {
+      const myId = socketClient?.id || currentPlayerId;
+      weaponManagerRef.current.equip("laser");
+      gameManager?.updatePlayer(myId, { equippedWeaponId: "laser" });
+    }
+    if (key2 && !prevKey2Ref.current) {
+      const myId = socketClient?.id || currentPlayerId;
+      weaponManagerRef.current.equip("shotgun");
+      gameManager?.updatePlayer(myId, { equippedWeaponId: "shotgun" });
+    }
+    prevKey1Ref.current = key1;
+    prevKey2Ref.current = key2;
+
+    // Fire the equipped weapon while left-click is held (rate-limited by
     // WeaponManager's per-shooter cooldown).
     if (mouseControls.leftClick && gameManager) {
       const fireDirection = new THREE.Vector3(
@@ -872,7 +893,7 @@ export const PlayerCharacter = React.forwardRef<
           </mesh>
         )}
       </group>
-      {/* Laser beam visual: a short-lived stretched box from the shooter
+      {/* Weapon beam visual: a short-lived stretched box from the shooter
           toward the hit point (or weapon range on a miss). */}
       <group ref={laserBeamRef} visible={false}>
         <mesh>

--- a/src/components/combat/WeaponManager.ts
+++ b/src/components/combat/WeaponManager.ts
@@ -15,6 +15,13 @@ export const WEAPONS: Record<string, WeaponConfig> = {
     range: 30,
     cooldownMs: 500,
   },
+  shotgun: {
+    id: "shotgun",
+    name: "Pulse Shotgun",
+    damage: 25,
+    range: 8,
+    cooldownMs: 1000,
+  },
 };
 
 /**

--- a/src/components/combat/__tests__/WeaponManager.test.ts
+++ b/src/components/combat/__tests__/WeaponManager.test.ts
@@ -56,4 +56,35 @@ describe("WeaponManager", () => {
     expect(manager.getEquipped()).toBeNull();
     expect(manager.fire("p1", 1000)).toBeNull();
   });
+
+  it("shotgun has higher damage and shorter range than laser", () => {
+    expect(WEAPONS.shotgun).toBeDefined();
+    expect(WEAPONS.shotgun.damage).toBeGreaterThan(WEAPONS.laser.damage);
+    expect(WEAPONS.shotgun.range).toBeLessThan(WEAPONS.laser.range);
+    expect(WEAPONS.shotgun.cooldownMs).toBeGreaterThan(
+      WEAPONS.laser.cooldownMs,
+    );
+  });
+
+  it("can switch between laser and shotgun", () => {
+    const manager = new WeaponManager();
+    manager.equip("laser");
+    expect(manager.getEquipped()?.id).toBe("laser");
+
+    manager.equip("shotgun");
+    expect(manager.getEquipped()?.id).toBe("shotgun");
+    expect(manager.getEquipped()).toEqual(WEAPONS.shotgun);
+  });
+
+  it("shotgun enforces its own cooldown independently", () => {
+    const manager = new WeaponManager();
+    manager.equip("shotgun");
+
+    expect(manager.fire("p1", 1000)).toEqual(WEAPONS.shotgun);
+    // Still in cooldown (shotgun cooldownMs = 1000)
+    expect(manager.canFire("p1", 1500)).toBe(false);
+    // After cooldown
+    expect(manager.canFire("p1", 2001)).toBe(true);
+    expect(manager.fire("p1", 2001)).toEqual(WEAPONS.shotgun);
+  });
 });

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -6,6 +6,8 @@ export const Q = "q";
 export const E = "e";
 export const SHIFT = "shift";
 export const SPACE = " ";
+export const KEY_1 = "1";
+export const KEY_2 = "2";
 export const DIRECTIONS = [W, A, S, D, Q, E];
 
 export class KeyDisplay {

--- a/src/lib/hooks/useKeyboardControls.ts
+++ b/src/lib/hooks/useKeyboardControls.ts
@@ -1,5 +1,16 @@
 import { useState, useEffect, useRef } from "react";
-import { W, A, S, D, Q, E, SHIFT, SPACE } from "../../components/utils";
+import {
+  W,
+  A,
+  S,
+  D,
+  Q,
+  E,
+  SHIFT,
+  SPACE,
+  KEY_1,
+  KEY_2,
+} from "../../components/utils";
 
 export type KeyMap = { [key: string]: boolean };
 
@@ -9,7 +20,7 @@ export type KeyMap = { [key: string]: boolean };
  */
 export const useKeyboardControls = (
   chatVisible: boolean,
-  isPaused: boolean
+  isPaused: boolean,
 ) => {
   const [keysPressed, setKeysPressed] = useState<KeyMap>({
     [W]: false,
@@ -20,6 +31,8 @@ export const useKeyboardControls = (
     [E]: false,
     [SHIFT]: false,
     [SPACE]: false,
+    [KEY_1]: false,
+    [KEY_2]: false,
   });
 
   const keysPressedRef = useRef(keysPressed);


### PR DESCRIPTION
## Summary

- Adds **Pulse Shotgun** to the `WEAPONS` registry: `{ damage: 25, range: 8, cooldownMs: 1000 }` — high burst, short range, slow fire rate vs. Laser Blaster's long-range rapid fire
- Press **1** to equip Laser Blaster, **2** to equip Pulse Shotgun (rising-edge detection in `PlayerCharacter.useFrame`)
- Equipped weapon name shown in the deathmatch and CTF HUD via `Player.equippedWeaponId` field
- `useKeyboardControls` now tracks `KEY_1`/`KEY_2` digit keys alongside WASD/SHIFT/SPACE

## Test plan

- [x] `WeaponManager.test.ts`: shotgun config assertions + switch between weapons + shotgun cooldown
- [x] `GameUI.test.tsx`: weapon name visible in deathmatch and CTF active HUD
- [x] `PlayerCharacter.frame.test.tsx` / `handle.test.tsx`: updated mocks to include `updatePlayer`
- [x] Full Docker suite: 838 passed, 0 failed, 10 skipped (848 total) ✅
- [x] Typecheck and lint clean (`--max-warnings=0`) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)