### PR TITLE
Phase E.2: weapon beam colors + distinct bot weapons

### DIFF
--- a/src/components/characters/PlayerCharacter.tsx
+++ b/src/components/characters/PlayerCharacter.tsx
@@ -151,6 +151,7 @@ export const PlayerCharacter = React.forwardRef<
   const [showJetpackFlame, setShowJetpackFlame] = useState(false);
   const lookIndicatorRef = React.useRef<THREE.Group>(null);
   const laserBeamRef = React.useRef<THREE.Group>(null);
+  const beamMeshRef = React.useRef<THREE.Mesh>(null);
   const laserBeamHideAtRef = React.useRef(0);
   const weaponManagerRef = React.useRef(new WeaponManager());
   const prevKey1Ref = React.useRef(false);
@@ -422,14 +423,25 @@ export const PlayerCharacter = React.forwardRef<
 
       if (fireResult && laserBeamRef.current) {
         const beamLength = fireResult.hit?.distance ?? fireResult.weapon.range;
+        const isShotgun = fireResult.weapon.id === "shotgun";
+        const beamHalfWidth = isShotgun ? 0.1 : 0.04;
         laserBeamRef.current.visible = true;
         laserBeamRef.current.position
           .copy(fireOrigin)
           .add(fireDirection.clone().multiplyScalar(beamLength / 2));
         laserBeamRef.current.rotation.y =
           cameraRotationRef.current.horizontal + Math.PI;
-        laserBeamRef.current.scale.set(1, 1, beamLength);
+        laserBeamRef.current.scale.set(
+          beamHalfWidth / 0.04,
+          beamHalfWidth / 0.04,
+          beamLength,
+        );
         laserBeamHideAtRef.current = now + LASER_BEAM_VISIBLE_MS;
+        if (beamMeshRef.current) {
+          (beamMeshRef.current.material as THREE.MeshBasicMaterial).color.set(
+            isShotgun ? "#ff7700" : "#33ffe6",
+          );
+        }
       }
     }
 
@@ -894,9 +906,10 @@ export const PlayerCharacter = React.forwardRef<
         )}
       </group>
       {/* Weapon beam visual: a short-lived stretched box from the shooter
-          toward the hit point (or weapon range on a miss). */}
+          toward the hit point (or weapon range on a miss). Color and width
+          are updated imperatively in useFrame based on equipped weapon. */}
       <group ref={laserBeamRef} visible={false}>
-        <mesh>
+        <mesh ref={beamMeshRef}>
           <boxGeometry args={[0.04, 0.04, 1]} />
           <meshBasicMaterial color="#33ffe6" transparent opacity={0.85} />
         </mesh>

--- a/src/pages/Solo/components/Bots.tsx
+++ b/src/pages/Solo/components/Bots.tsx
@@ -175,12 +175,12 @@ const Bots: React.FC<
     }
   }, [gameManager, bot2IsIt, bot1IsIt, setBot1GotTagged]);
 
-  // Shared laser for both bots; WeaponManager tracks per-shooter cooldowns,
-  // so one instance is the authoritative fire-rate gate for bot-1 and bot-2.
-  // Lazily initialized inside the fire handler to satisfy react-hooks/refs.
-  const botWeaponsRef = useRef<WeaponManager | null>(null);
+  // Each bot gets its own WeaponManager so they can use different weapons.
+  // Bot-1 uses the Pulse Shotgun (close-range burst); bot-2 uses the Laser Blaster.
+  const bot1WeaponsRef = useRef<WeaponManager | null>(null);
+  const bot2WeaponsRef = useRef<WeaponManager | null>(null);
 
-  const fireBotLaser = useCallback(
+  const fireBotWeapon = useCallback(
     (botId: string, targetId: string) => {
       if (
         !gameManager ||
@@ -190,12 +190,14 @@ const Bots: React.FC<
         return;
       }
 
-      if (!botWeaponsRef.current) {
-        botWeaponsRef.current = new WeaponManager();
-        botWeaponsRef.current.equip("laser");
+      const isBot1 = botId === "bot-1";
+      const weaponRef = isBot1 ? bot1WeaponsRef : bot2WeaponsRef;
+      if (!weaponRef.current) {
+        weaponRef.current = new WeaponManager();
+        weaponRef.current.equip(isBot1 ? "shotgun" : "laser");
       }
 
-      const weapon = botWeaponsRef.current.fire(botId);
+      const weapon = weaponRef.current.fire(botId);
       if (!weapon) return; // still on cooldown
 
       const hitLanded = gameManager.hitPlayer(botId, targetId, weapon.damage);
@@ -211,12 +213,12 @@ const Bots: React.FC<
   );
 
   const handleBot1FireAtTarget = useCallback(() => {
-    fireBotLaser("bot-1", botDebugMode ? "bot-2" : currentPlayerId);
-  }, [fireBotLaser, botDebugMode, currentPlayerId]);
+    fireBotWeapon("bot-1", botDebugMode ? "bot-2" : currentPlayerId);
+  }, [fireBotWeapon, botDebugMode, currentPlayerId]);
 
   const handleBot2FireAtTarget = useCallback(() => {
-    fireBotLaser("bot-2", "bot-1");
-  }, [fireBotLaser]);
+    fireBotWeapon("bot-2", "bot-1");
+  }, [fireBotWeapon]);
 
   return (
     <>

--- a/src/pages/Solo/components/__tests__/Bots.test.tsx
+++ b/src/pages/Solo/components/__tests__/Bots.test.tsx
@@ -189,7 +189,7 @@ describe("Bots", () => {
     expect(gm.getPlayers().get("bot-1")?.isIt).toBe(false);
   });
 
-  it("routes bot laser fire through hitPlayer with the weapon cooldown in deathmatch", () => {
+  it("routes bot fire through hitPlayer with the weapon cooldown in deathmatch", () => {
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(5000);
 
     const gm = new GameManager();
@@ -207,17 +207,18 @@ describe("Bots", () => {
     render(<Bots {...props} />);
     const fire = botPropsByRender[0].onFireAtTarget as () => void;
 
+    // bot-1 uses the Pulse Shotgun (damage 25, cooldown 1000ms)
     fire();
-    expect(gm.getPlayers().get("player-1")?.health).toBe(90);
+    expect(gm.getPlayers().get("player-1")?.health).toBe(75);
 
-    // Still within the laser's 500ms cooldown - the shot is gated.
+    // Still within the shotgun's 1000ms cooldown - the shot is gated.
     fire();
-    expect(gm.getPlayers().get("player-1")?.health).toBe(90);
+    expect(gm.getPlayers().get("player-1")?.health).toBe(75);
 
     // Cooldown elapsed - the next shot lands.
-    nowSpy.mockReturnValue(5600);
+    nowSpy.mockReturnValue(6001);
     fire();
-    expect(gm.getPlayers().get("player-1")?.health).toBe(80);
+    expect(gm.getPlayers().get("player-1")?.health).toBe(50);
   });
 
   it("marks a bot as downed while it awaits respawn in deathmatch", () => {
@@ -297,7 +298,8 @@ describe("Bots", () => {
     const fire = botPropsByRender[0].onFireAtTarget as () => void;
 
     fire();
-    expect(gm.getPlayers().get("player-1")?.health).toBe(90);
+    // bot-1 equips the Pulse Shotgun (damage 25), so 100 - 25 = 75
+    expect(gm.getPlayers().get("player-1")?.health).toBe(75);
 
     nowSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary

- **Beam color differentiation**: the weapon beam now uses cyan (#33ffe6, thin) for Laser Blaster and orange (#ff7700, 2.5× wider) for Pulse Shotgun — players get instant visual feedback on which weapon is firing
- **Distinct bot weapons**: Bot-1 equips the Pulse Shotgun (25 damage, close-range, 1s cooldown) and Bot-2 equips the Laser Blaster (10 damage, long-range, 0.5s cooldown) — each bot presents a different combat threat style
- Both changes are backward-compatible: tests updated to reflect new shotgun damage values for bot-1

## Test plan

- [x] Updated `Bots.test.tsx` expectations for bot-1 shotgun damage (75 after first hit, not 90)
- [x] Updated cooldown timing test: shotgun's 1000ms cooldown requires advancing to t=6001 not t=5600
- [x] Full Docker suite: 838 passed, 0 failed ✅
- [x] Pre-commit lint + pre-push test suite passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)