### PR TITLE
Phase E.3: world weapon pickup crates (shotgun/laser, 15s respawn)

### DIFF
--- a/src/__tests__/PlayerCharacter.handle.test.tsx
+++ b/src/__tests__/PlayerCharacter.handle.test.tsx
@@ -99,6 +99,50 @@ const fakeGameManager: FakeGameManagerWithUpdate = {
 };
 
 describe("PlayerCharacter imperative handle", () => {
+  it("equips a picked-up weapon via the weapon-pickup window event", () => {
+    const updatePlayer = vi.fn();
+    const gm = {
+      getPlayers: () => new Map(),
+      getGameState: () => ({ mode: "tag", isActive: false }),
+      updatePlayer,
+    };
+
+    render(
+      <div data-testid="canvas">
+        <PlayerCharacter
+          keysPressedRef={{ current: {} }}
+          socketClient={null}
+          mouseControls={{
+            leftClick: false,
+            rightClick: false,
+            middleClick: false,
+            mouseX: 0,
+            mouseY: 0,
+          }}
+          clients={emptyClients}
+          gameManager={
+            gm as unknown as import("../components/GameManager").GameManager
+          }
+          currentPlayerId="p1"
+          joystickMove={{ x: 0, y: 0 }}
+          joystickCamera={{ x: 0, y: 0 }}
+          lastWalkSoundTimeRef={{ current: 0 }}
+          isPaused={true}
+        />
+      </div>,
+    );
+
+    window.dispatchEvent(
+      new window.CustomEvent("weapon-pickup", {
+        detail: { weaponId: "shotgun" },
+      }),
+    );
+
+    expect(updatePlayer).toHaveBeenCalledWith("p1", {
+      equippedWeaponId: "shotgun",
+    });
+  });
+
   it("exposes resetPosition and freezePlayer on ref (safe calls)", () => {
     const ref = React.createRef<PlayerCharacterHandle>();
 

--- a/src/components/characters/PlayerCharacter.tsx
+++ b/src/components/characters/PlayerCharacter.tsx
@@ -202,6 +202,20 @@ export const PlayerCharacter = React.forwardRef<
     };
   }, [isPlayerFrozenRef, playerFreezeEndTimeRef]);
 
+  // Equip a weapon picked up from a world pickup item (WeaponPickups fires this event).
+  React.useEffect(() => {
+    function handleWeaponPickup(e: unknown) {
+      const { weaponId } = (e as { detail: { weaponId: string } }).detail;
+      weaponManagerRef.current.equip(weaponId);
+      gameManager?.updatePlayer(currentPlayerId, {
+        equippedWeaponId: weaponId,
+      });
+    }
+    window.addEventListener("weapon-pickup", handleWeaponPickup);
+    return () =>
+      window.removeEventListener("weapon-pickup", handleWeaponPickup);
+  }, [gameManager, currentPlayerId]);
+
   // gated debug logger - only logs in dev
   const debug = (...args: unknown[]) => {
     // Vite exposes import.meta.env.DEV; fall back to false if undefined

--- a/src/components/world/WeaponPickups.tsx
+++ b/src/components/world/WeaponPickups.tsx
@@ -1,0 +1,150 @@
+import * as React from "react";
+import * as THREE from "three";
+import { useFrame } from "@react-three/fiber";
+import type { GameState } from "../GameManager";
+
+const PICKUP_RADIUS = 2;
+const RESPAWN_MS = 15000;
+const BOB_AMPLITUDE = 0.1;
+const BOB_FREQUENCY = 500;
+const SPIN_SPEED = 2;
+
+type PickupDef = {
+  id: string;
+  position: [number, number, number];
+  weaponId: string;
+  color: string;
+};
+
+export const PICKUP_DEFS: PickupDef[] = [
+  {
+    id: "pickup-center-shotgun",
+    position: [0, 0.8, 0],
+    weaponId: "shotgun",
+    color: "#ff7700",
+  },
+  {
+    id: "pickup-left-laser",
+    position: [-10, 0.8, 0],
+    weaponId: "laser",
+    color: "#33ffe6",
+  },
+  {
+    id: "pickup-right-laser",
+    position: [10, 0.8, 0],
+    weaponId: "laser",
+    color: "#33ffe6",
+  },
+];
+
+type PickupState = {
+  visible: boolean;
+  respawnAt: number | null;
+};
+
+export interface WeaponPickupsProps {
+  playerPositionRef: React.RefObject<[number, number, number]>;
+  gameState: GameState;
+}
+
+const WeaponPickups: React.FC<WeaponPickupsProps> = ({
+  playerPositionRef,
+  gameState,
+}) => {
+  const groupRefs = React.useRef<(THREE.Group | null)[]>(
+    PICKUP_DEFS.map(() => null),
+  );
+  const pickupStates = React.useRef<PickupState[]>(
+    PICKUP_DEFS.map(() => ({ visible: true, respawnAt: null })),
+  );
+
+  useFrame((_, delta) => {
+    const isActive =
+      gameState.isActive &&
+      (gameState.mode === "deathmatch" || gameState.mode === "ctf");
+
+    if (!isActive) {
+      groupRefs.current.forEach((g) => {
+        if (g) g.visible = false;
+      });
+      return;
+    }
+
+    const now = Date.now();
+    const playerPos = playerPositionRef.current;
+
+    for (let i = 0; i < PICKUP_DEFS.length; i++) {
+      const state = pickupStates.current[i];
+      const def = PICKUP_DEFS[i];
+      const group = groupRefs.current[i];
+
+      // Respawn check
+      if (
+        !state.visible &&
+        state.respawnAt !== null &&
+        now >= state.respawnAt
+      ) {
+        state.visible = true;
+        state.respawnAt = null;
+      }
+
+      if (!group) continue;
+      group.visible = state.visible;
+
+      if (!state.visible) continue;
+
+      // Animate: spin and bob
+      group.rotation.y += delta * SPIN_SPEED;
+      group.position.y =
+        def.position[1] + Math.sin(now / BOB_FREQUENCY) * BOB_AMPLITUDE;
+
+      // Proximity check (XZ plane only — ignore height difference)
+      if (playerPos) {
+        const dx = playerPos[0] - def.position[0];
+        const dz = playerPos[2] - def.position[2];
+        if (Math.sqrt(dx * dx + dz * dz) < PICKUP_RADIUS) {
+          state.visible = false;
+          state.respawnAt = now + RESPAWN_MS;
+          window.dispatchEvent(
+            new window.CustomEvent("weapon-pickup", {
+              detail: { weaponId: def.weaponId },
+            }),
+          );
+        }
+      }
+    }
+  });
+
+  /* eslint-disable react/no-unknown-property */
+  return (
+    <>
+      {PICKUP_DEFS.map((def, i) => (
+        <group
+          key={def.id}
+          ref={(el: THREE.Group | null) => {
+            groupRefs.current[i] = el;
+          }}
+          position={def.position}
+          visible={false}
+        >
+          <mesh>
+            <boxGeometry args={[0.4, 0.4, 0.4]} />
+            <meshBasicMaterial color={def.color} transparent opacity={0.9} />
+          </mesh>
+          <mesh>
+            <boxGeometry args={[0.45, 0.45, 0.45]} />
+            <meshBasicMaterial
+              color={def.color}
+              wireframe
+              transparent
+              opacity={0.4}
+            />
+          </mesh>
+        </group>
+      ))}
+    </>
+  );
+  /* eslint-enable react/no-unknown-property */
+};
+
+export default WeaponPickups;

--- a/src/components/world/__tests__/WeaponPickups.test.ts
+++ b/src/components/world/__tests__/WeaponPickups.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { PICKUP_DEFS } from "../WeaponPickups";
+import { WEAPONS } from "../../combat/WeaponManager";
+
+describe("WeaponPickups pickup definitions", () => {
+  it("every pickup references a valid weapon", () => {
+    for (const def of PICKUP_DEFS) {
+      expect(WEAPONS[def.weaponId]).toBeDefined();
+    }
+  });
+
+  it("has at least one pickup for each weapon type", () => {
+    const weaponIds = new Set(PICKUP_DEFS.map((d) => d.weaponId));
+    expect(weaponIds.has("laser")).toBe(true);
+    expect(weaponIds.has("shotgun")).toBe(true);
+  });
+
+  it("pickup positions have non-negative Y (above ground)", () => {
+    for (const def of PICKUP_DEFS) {
+      expect(def.position[1]).toBeGreaterThan(0);
+    }
+  });
+
+  it("all pickup ids are unique", () => {
+    const ids = PICKUP_DEFS.map((d) => d.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/src/pages/Solo/components/SoloScene.tsx
+++ b/src/pages/Solo/components/SoloScene.tsx
@@ -3,6 +3,7 @@ import { Canvas } from "@react-three/fiber";
 import Environment from "./Environment";
 import Players from "./Players";
 import Bots from "./Bots";
+import WeaponPickups from "../../../components/world/WeaponPickups";
 import type { SoloSceneProps } from "./SoloScene.types";
 
 type Props = SoloSceneProps;
@@ -98,6 +99,11 @@ export const SoloScene: React.FC<Props> = ({
         bot2GotTagged={bot2GotTagged}
         BOT1_CONFIG={BOT1_CONFIG}
         BOT2_CONFIG={BOT2_CONFIG}
+      />
+
+      <WeaponPickups
+        playerPositionRef={playerPositionRef}
+        gameState={gameState}
       />
     </Canvas>
   );


### PR DESCRIPTION
## Summary
- Adds `WeaponPickups` component rendering 3 spinning pickup crates in the world: center=Pulse Shotgun (orange), left/right=Laser Blaster (cyan)
- Proximity check (< 2 units XZ) auto-equips the weapon via a `weapon-pickup` window event, then crate disappears for 15s before respawning
- `PlayerCharacter` listens for the event and calls `weaponManagerRef.equip` + `gameManager.updatePlayer` to sync state

## Test plan
- [ ] `WeaponPickups.test.ts`: 4 tests validating PICKUP_DEFS reference valid weapons, cover both types, have positive Y, and have unique ids
- [ ] `PlayerCharacter.handle.test.tsx`: weapon-pickup event equips the weapon and calls `updatePlayer`
- [ ] All 843 tests pass (10 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)