### PR TITLE
Phase N: kill streak announcements — KILLING SPREE / RAMPAGE / UNSTOPPABLE / GODLIKE

### DIFF
--- a/src/__tests__/gameManager.deathmatch.test.ts
+++ b/src/__tests__/gameManager.deathmatch.test.ts
@@ -200,6 +200,86 @@ describe("GameManager deathmatch", () => {
     }
   });
 
+  it("tracks kill streak and announces on threshold kills", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+
+    vi.spyOn(Date, "now").mockReturnValue(10000);
+    manager.startDeathmatchGame();
+
+    const p1 = manager.getPlayers().get("p1")!;
+
+    // 2 kills — no threshold yet
+    manager.hitPlayer("p1", "p2", 1000);
+    expect(p1.currentKillStreak).toBe(1);
+    expect(manager.getGameState().streakAnnouncement).toBeUndefined();
+
+    // Respawn p2
+    manager.getPlayers().get("p2")!.respawnAt = undefined;
+    manager.getPlayers().get("p2")!.health = 100;
+    manager.hitPlayer("p1", "p2", 1000);
+    expect(p1.currentKillStreak).toBe(2);
+
+    // Third kill hits the threshold → announcement
+    manager.getPlayers().get("p2")!.respawnAt = undefined;
+    manager.getPlayers().get("p2")!.health = 100;
+    manager.hitPlayer("p1", "p2", 1000);
+    expect(p1.currentKillStreak).toBe(3);
+
+    const ann = manager.getGameState().streakAnnouncement;
+    expect(ann).toBeDefined();
+    expect(ann!.killerName).toBe("P1");
+    expect(ann!.count).toBe(3);
+  });
+
+  it("resets kill streak to 0 when a player dies", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+
+    vi.spyOn(Date, "now").mockReturnValue(10000);
+    manager.startDeathmatchGame();
+
+    const p1 = manager.getPlayers().get("p1")!;
+    const p2 = manager.getPlayers().get("p2")!;
+
+    // p1 gets 2 kills
+    manager.hitPlayer("p1", "p2", 1000);
+    p2.respawnAt = undefined;
+    p2.health = 100;
+    manager.hitPlayer("p1", "p2", 1000);
+    expect(p1.currentKillStreak).toBe(2);
+
+    // p2 kills p1 — streak resets
+    p2.respawnAt = undefined;
+    p2.health = 100;
+    manager.hitPlayer("p2", "p1", 1000);
+    expect(p1.currentKillStreak).toBe(0);
+  });
+
+  it("streak announcement is cleared by onTick after the display window", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+
+    vi.spyOn(Date, "now").mockReturnValue(10000);
+    manager.startDeathmatchGame();
+
+    // Force a 3-kill streak
+    for (let i = 0; i < 3; i++) {
+      manager.getPlayers().get("p2")!.respawnAt = undefined;
+      manager.getPlayers().get("p2")!.health = 100;
+      manager.hitPlayer("p1", "p2", 1000);
+    }
+    expect(manager.getGameState().streakAnnouncement).toBeDefined();
+
+    // Advance past the 3-second display window
+    vi.spyOn(Date, "now").mockReturnValue(13100);
+    manager.updateGameTimer(0.1);
+    expect(manager.getGameState().streakAnnouncement).toBeUndefined();
+  });
+
   it("ends the game once a player reaches the kill limit, with results sorted by kills", () => {
     const manager = new GameManager();
     manager.addPlayer(makePlayer("p1", "P1"));

--- a/src/components/GameManager.ts
+++ b/src/components/GameManager.ts
@@ -37,6 +37,8 @@ export interface GameState {
   flags?: CTFFlag[];
   /** Scrolling kill feed (last 10 kills). */
   killFeed?: KillEvent[];
+  /** Transient streak announcement, cleared by onTick after display window. */
+  streakAnnouncement?: { killerName: string; count: number; timestamp: number };
 }
 
 export interface TagGameState extends GameState {
@@ -69,6 +71,8 @@ export interface Player {
   currentAmmo?: number | null;
   /** Timestamp (ms) until which this player is invincible after respawning. */
   spawnProtectedUntil?: number;
+  /** Consecutive kills without dying (resets on death). */
+  currentKillStreak?: number;
 }
 
 export class GameManager {

--- a/src/components/GameUI.tsx
+++ b/src/components/GameUI.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { GameState, KillEvent, Player } from "./GameManager";
 import { WEAPONS } from "./combat/WeaponManager";
+import { STREAK_LABELS } from "./gameModes/DeathmatchMode";
 
 interface GameUIProps {
   gameState: GameState;
@@ -56,6 +57,24 @@ const GameUI: React.FC<GameUIProps> = ({
 
   // spawnProtectedUntil is cleared by onTick within ~1s of expiry — presence is enough.
   const isSpawnProtected = currentPlayer?.spawnProtectedUntil !== undefined;
+
+  // Streak announcement: show briefly then fade; onTick clears the field after 3s.
+  const streakAnnouncement = gameState.streakAnnouncement;
+  const [visibleStreak, setVisibleStreak] = React.useState<{
+    killerName: string;
+    count: number;
+  } | null>(null);
+
+  React.useEffect(() => {
+    if (streakAnnouncement === undefined) {
+      setVisibleStreak(null);
+      return;
+    }
+    setVisibleStreak({
+      killerName: streakAnnouncement.killerName,
+      count: streakAnnouncement.count,
+    });
+  }, [streakAnnouncement]);
 
   // Respawn countdown: restart the interval whenever the player's respawnAt stamp changes.
   const respawnAt = currentPlayer?.respawnAt;
@@ -567,6 +586,45 @@ const GameUI: React.FC<GameUIProps> = ({
               }}
             >
               PROTECTED
+            </div>
+          )}
+
+        {visibleStreak !== null &&
+          (gameState.mode === "deathmatch" || gameState.mode === "ctf") && (
+            <div
+              style={{
+                position: "fixed",
+                top: "30%",
+                left: "50%",
+                transform: "translateX(-50%)",
+                pointerEvents: "none",
+                zIndex: 995,
+                textAlign: "center",
+              }}
+            >
+              <div
+                style={{
+                  fontFamily: "monospace",
+                  fontSize: isMinimal ? "14px" : "26px",
+                  fontWeight: "bold",
+                  color: "#ffcc00",
+                  textShadow: "0 0 18px #ff8800, 0 0 6px #ffcc00",
+                  letterSpacing: "3px",
+                }}
+              >
+                {STREAK_LABELS[visibleStreak.count] ??
+                  `${visibleStreak.count}x STREAK`}
+              </div>
+              <div
+                style={{
+                  fontFamily: "monospace",
+                  fontSize: isMinimal ? "10px" : "14px",
+                  color: "#ffeeaa",
+                  marginTop: "4px",
+                }}
+              >
+                {visibleStreak.killerName}
+              </div>
             </div>
           )}
       </>

--- a/src/components/gameModes/DeathmatchMode.ts
+++ b/src/components/gameModes/DeathmatchMode.ts
@@ -8,6 +8,15 @@ import type {
 
 const log = createLogger("DeathmatchMode");
 
+const STREAK_THRESHOLDS = [3, 5, 7, 10] as const;
+const STREAK_LABELS: Record<number, string> = {
+  3: "KILLING SPREE",
+  5: "RAMPAGE",
+  7: "UNSTOPPABLE",
+  10: "GODLIKE",
+};
+const STREAK_ANNOUNCE_MS = 3000;
+
 /**
  * Deathmatch rules: every player starts with full health and damages others
  * with weapon hits. A lethal hit awards the attacker a kill and puts the
@@ -24,6 +33,7 @@ export class DeathmatchMode implements GameModeHandler {
       player.maxHealth = player.maxHealth ?? this.DEFAULT_MAX_HEALTH;
       player.health = player.maxHealth;
       player.respawnAt = undefined;
+      player.currentKillStreak = 0;
     });
   }
 
@@ -49,6 +59,14 @@ export class DeathmatchMode implements GameModeHandler {
         player.spawnProtectedUntil = undefined;
       }
     });
+
+    // Expire streak announcement after display window
+    if (
+      gameState.streakAnnouncement !== undefined &&
+      now >= gameState.streakAnnouncement.timestamp + STREAK_ANNOUNCE_MS
+    ) {
+      gameState.streakAnnouncement = undefined;
+    }
   }
 
   onAction(
@@ -81,8 +99,21 @@ export class DeathmatchMode implements GameModeHandler {
       gameState.scores[attackerId] = (gameState.scores[attackerId] ?? 0) + 1;
       target.respawnAt = Date.now() + this.RESPAWN_DELAY_MS;
 
+      // Streak: increment attacker, reset target
+      attacker.currentKillStreak = (attacker.currentKillStreak ?? 0) + 1;
+      target.currentKillStreak = 0;
+
+      const streak = attacker.currentKillStreak;
+      if ((STREAK_THRESHOLDS as readonly number[]).includes(streak)) {
+        gameState.streakAnnouncement = {
+          killerName: attacker.name,
+          count: streak,
+          timestamp: Date.now(),
+        };
+      }
+
       log.debug(
-        `${attacker.name} eliminated ${target.name}! (${gameState.scores[attackerId]} kills)`,
+        `${attacker.name} eliminated ${target.name}! (${gameState.scores[attackerId]} kills, streak: ${attacker.currentKillStreak})`,
       );
 
       const killEvent: KillEvent = {
@@ -125,10 +156,15 @@ export class DeathmatchMode implements GameModeHandler {
       player.health = player.maxHealth;
       player.respawnAt = undefined;
       player.spawnProtectedUntil = undefined;
+      player.currentKillStreak = 0;
     });
+
+    gameState.streakAnnouncement = undefined;
 
     return results;
   }
 }
 
 export default DeathmatchMode;
+
+export { STREAK_LABELS };


### PR DESCRIPTION
## Summary
- Tracks `currentKillStreak` per player in `DeathmatchMode`; increments on kill, resets to 0 on death
- Announces at 3/5/7/10 kills via `gameState.streakAnnouncement`; `onTick` clears it after 3s
- `GameUI` renders a golden flashing banner ("KILLING SPREE", "RAMPAGE", etc.) with the killer's name, using a `useEffect` to avoid `Date.now()` in render
- 3 new tests: threshold detection, reset on death, expiry via tick

## Test plan
- [x] 474 passing, 5 skipped — all green on push
- [x] ESLint `--max-warnings=0` clean (no impure render calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)