### PR TITLE
Phase P: end-of-game results screen — VICTORY/DEFEATED with scores and Play Again

### DIFF
--- a/src/components/GameManager.ts
+++ b/src/components/GameManager.ts
@@ -1,5 +1,9 @@
 import { createLogger } from "../lib/utils/logger";
-import type { CTFFlag, GameModeHandler } from "./gameModes/GameModeHandler";
+import type {
+  CTFFlag,
+  GameModeHandler,
+  GameResult,
+} from "./gameModes/GameModeHandler";
 
 export interface KillEvent {
   killerId: string;
@@ -39,6 +43,8 @@ export interface GameState {
   killFeed?: KillEvent[];
   /** Transient streak announcement, cleared by onTick after display window. */
   streakAnnouncement?: { killerName: string; count: number; timestamp: number };
+  /** Sorted results from the most recently ended game, cleared on next start. */
+  gameResults?: GameResult[];
 }
 
 export interface TagGameState extends GameState {
@@ -329,6 +335,7 @@ export class GameManager {
     this.gameState.timeRemaining = 0;
 
     const results = this.mode.onEnd(this.players, this.gameState);
+    this.gameState.gameResults = results;
 
     log.debug("Game ended! Final scores:", results);
 

--- a/src/components/GameUI.tsx
+++ b/src/components/GameUI.tsx
@@ -631,6 +631,126 @@ const GameUI: React.FC<GameUIProps> = ({
     );
   }
 
+  // Results screen — shown after an active game ends until the player starts a new one.
+  if (
+    !gameState.isActive &&
+    gameState.gameResults &&
+    gameState.gameResults.length > 0
+  ) {
+    const winner = gameState.gameResults[0];
+    const isWinner = winner.id === currentPlayerId;
+    const scoreLabel =
+      gameState.mode === "ctf"
+        ? "caps"
+        : gameState.mode === "tag"
+          ? "pts"
+          : "kills";
+    return (
+      <div
+        style={{
+          position: "fixed",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          backgroundColor: "rgba(0,0,0,0.92)",
+          border: "2px solid rgba(255,255,255,0.3)",
+          borderRadius: "10px",
+          color: "white",
+          fontFamily: "monospace",
+          fontSize: isMinimal ? "10px" : "13px",
+          zIndex: 1001,
+          minWidth: isMinimal ? "160px" : "240px",
+          textAlign: "center",
+          padding: isMinimal ? "10px 12px" : "20px 28px",
+        }}
+      >
+        <div
+          style={{
+            fontSize: isMinimal ? "18px" : "28px",
+            fontWeight: "bold",
+            color: isWinner ? "#ffdd44" : "#ff6666",
+            textShadow: isWinner ? "0 0 14px #ffaa00" : "0 0 10px #ff4444",
+            marginBottom: "10px",
+            letterSpacing: "2px",
+          }}
+        >
+          {isWinner ? "VICTORY!" : "DEFEATED"}
+        </div>
+
+        <div
+          style={{
+            marginBottom: "12px",
+            fontSize: isMinimal ? "10px" : "12px",
+            color: "#aaa",
+          }}
+        >
+          {gameState.mode.toUpperCase()} — FINAL SCORES
+        </div>
+
+        <div style={{ marginBottom: "14px" }}>
+          {gameState.gameResults.map((r, i) => (
+            <div
+              key={r.id}
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                gap: "16px",
+                padding: "3px 0",
+                color:
+                  r.id === currentPlayerId
+                    ? "#ffdd44"
+                    : i === 0
+                      ? "#ffffff"
+                      : "#aaaaaa",
+                fontWeight: r.id === currentPlayerId ? "bold" : "normal",
+              }}
+            >
+              <span>
+                {i + 1}. {r.name}
+              </span>
+              <span>
+                {r.score} {scoreLabel}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        <button
+          onClick={() => onStartGame(gameState.mode)}
+          style={{
+            padding: isMinimal ? "4px 8px" : "6px 14px",
+            backgroundColor: "rgba(74, 144, 226, 0.85)",
+            border: "1px solid #4a90e2",
+            borderRadius: "4px",
+            color: "white",
+            cursor: "pointer",
+            fontSize: isMinimal ? "10px" : "12px",
+            width: "100%",
+            marginBottom: "6px",
+          }}
+        >
+          Play Again
+        </button>
+
+        <button
+          onClick={onEndGame}
+          style={{
+            padding: isMinimal ? "3px 6px" : "4px 10px",
+            backgroundColor: "rgba(100,100,100,0.7)",
+            border: "1px solid #666",
+            borderRadius: "4px",
+            color: "#ccc",
+            cursor: "pointer",
+            fontSize: isMinimal ? "9px" : "10px",
+            width: "100%",
+          }}
+        >
+          Main Menu
+        </button>
+      </div>
+    );
+  }
+
   // Game lobby/start screen
   return (
     <div

--- a/src/components/__tests__/GameUI.test.tsx
+++ b/src/components/__tests__/GameUI.test.tsx
@@ -227,4 +227,67 @@ describe("GameUI", () => {
       screen.getByText("🚩 Carrying flag! Return to base!"),
     ).toBeInTheDocument();
   });
+
+  it("shows results screen after deathmatch ends, with Play Again and Main Menu buttons", () => {
+    const onStartGame = vi.fn();
+    const onEndGame = vi.fn();
+
+    const gameState: GameState = {
+      mode: "deathmatch",
+      isActive: false,
+      timeRemaining: 0,
+      scores: { p1: 7, p2: 3 },
+      gameResults: [
+        { id: "p1", name: "Player One", score: 7 },
+        { id: "p2", name: "Player Two", score: 3 },
+      ],
+    };
+
+    render(
+      <GameUI
+        gameState={gameState}
+        players={mkPlayers()}
+        currentPlayerId="p1"
+        onStartGame={onStartGame}
+        onEndGame={onEndGame}
+      />,
+    );
+
+    expect(screen.getByText("VICTORY!")).toBeInTheDocument();
+    expect(screen.getByText(/Player One/)).toBeInTheDocument();
+    expect(screen.getByText(/7 kills/)).toBeInTheDocument();
+    expect(screen.getByText(/Player Two/)).toBeInTheDocument();
+    expect(screen.getByText(/3 kills/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Play Again"));
+    expect(onStartGame).toHaveBeenCalledWith("deathmatch");
+
+    fireEvent.click(screen.getByText("Main Menu"));
+    expect(onEndGame).toHaveBeenCalled();
+  });
+
+  it("shows DEFEATED when the current player loses", () => {
+    const gameState: GameState = {
+      mode: "deathmatch",
+      isActive: false,
+      timeRemaining: 0,
+      scores: { p1: 2, p2: 8 },
+      gameResults: [
+        { id: "p2", name: "Player Two", score: 8 },
+        { id: "p1", name: "Player One", score: 2 },
+      ],
+    };
+
+    render(
+      <GameUI
+        gameState={gameState}
+        players={mkPlayers()}
+        currentPlayerId="p1"
+        onStartGame={vi.fn()}
+        onEndGame={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("DEFEATED")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- Stores sorted `GameResult[]` in `gameState.gameResults` inside `GameManager.endGame()` — cleared automatically on next `start*Game` (new gameState object)
- `GameUI` shows a centered overlay when `!isActive && gameResults.length > 0`: winner/loser headline, ranked score table with kills/caps/pts label, Play Again (same mode) and Main Menu buttons
- 2 new `GameUI.test.tsx` tests: VICTORY screen with button interactions, DEFEATED headline for runner-up

## Test plan
- [x] 479 passing, 5 skipped — all green
- [x] ESLint `--max-warnings=0` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)