### PR TITLE
Phase Q: CTF kill streaks + rocket splash parity + bot-2 Rocket Launcher

### DIFF
--- a/src/__tests__/gameManager.ctf.test.ts
+++ b/src/__tests__/gameManager.ctf.test.ts
@@ -272,4 +272,76 @@ describe("GameManager CTF", () => {
       { id: "p2", name: "P2", score: 0 },
     ]);
   });
+
+  it("a 3-kill streak in CTF triggers a streakAnnouncement", () => {
+    const manager = new GameManager();
+    // 4 players so p1 has multiple targets
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+    manager.addPlayer(makePlayer("p3", "P3"));
+    manager.addPlayer(makePlayer("p4", "P4"));
+
+    vi.spyOn(Date, "now").mockReturnValue(10000);
+    manager.startCTFGame();
+
+    expect(manager.getGameState().streakAnnouncement).toBeUndefined();
+
+    manager.hitPlayer("p1", "p2", 1000);
+    expect(manager.getGameState().streakAnnouncement).toBeUndefined(); // 1 kill
+
+    vi.spyOn(Date, "now").mockReturnValue(13001); // p2 respawns
+    manager.updateGameTimer(0.1);
+    vi.spyOn(Date, "now").mockReturnValue(15001); // p2 spawn protection expires
+    manager.updateGameTimer(0.1);
+
+    manager.hitPlayer("p1", "p3", 1000);
+    expect(manager.getGameState().streakAnnouncement).toBeUndefined(); // 2 kills
+
+    vi.spyOn(Date, "now").mockReturnValue(20000);
+    manager.hitPlayer("p1", "p4", 1000);
+    expect(manager.getGameState().streakAnnouncement).toEqual({
+      killerName: "P1",
+      count: 3,
+      timestamp: 20000,
+    });
+  });
+
+  it("kill streak resets on death in CTF", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1"));
+    manager.addPlayer(makePlayer("p2", "P2"));
+    manager.startCTFGame();
+
+    manager.hitPlayer("p1", "p2", 1000); // p1 streak = 1
+    expect(manager.getPlayers().get("p1")?.currentKillStreak).toBe(1);
+
+    vi.spyOn(Date, "now").mockReturnValue(13001);
+    manager.updateGameTimer(0.1); // p2 respawns
+    vi.spyOn(Date, "now").mockReturnValue(15001);
+    manager.updateGameTimer(0.1); // spawn protection expires
+
+    manager.hitPlayer("p2", "p1", 1000); // p2 kills p1 — p1 streak resets
+    expect(manager.getPlayers().get("p1")?.currentKillStreak).toBe(0);
+    expect(manager.getPlayers().get("p2")?.currentKillStreak).toBe(1);
+  });
+
+  it("rocket splash in CTF damages bystanders within radius and awards kill credit to attacker", () => {
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "P1", [0, 0, 0])); // attacker
+    manager.addPlayer(makePlayer("p2", "P2", [3, 0, 0])); // direct target
+    manager.addPlayer(makePlayer("p3", "P3", [5, 0, 0])); // bystander 2u from target → within splashRadius 5
+    manager.addPlayer(makePlayer("p4", "P4", [20, 0, 0])); // far bystander → outside splash
+
+    vi.spyOn(Date, "now").mockReturnValue(10000);
+    manager.startCTFGame();
+
+    // rocket: 100 dmg direct, splashRadius 5, splashDamage 50
+    manager.hitPlayer("p1", "p2", 100, "rocket");
+
+    const players = manager.getPlayers();
+    expect(players.get("p2")?.health).toBe(0); // direct kill
+    expect(players.get("p3")?.health).toBe(50); // splash hit (100 - 50)
+    expect(players.get("p4")?.health).toBe(100); // out of range
+    expect(players.get("p1")?.currentKillStreak).toBe(1); // kill credited
+  });
 });

--- a/src/components/gameModes/CTFMode.ts
+++ b/src/components/gameModes/CTFMode.ts
@@ -1,10 +1,12 @@
 import { createLogger } from "../../lib/utils/logger";
 import type { GameState, KillEvent, Player } from "../GameManager";
+import { WEAPONS } from "../combat/WeaponManager";
 import type {
   GameAction,
   GameModeHandler,
   GameResult,
 } from "./GameModeHandler";
+import { STREAK_THRESHOLDS, STREAK_ANNOUNCE_MS } from "./DeathmatchMode";
 
 const log = createLogger("CTFMode");
 
@@ -52,6 +54,7 @@ export class CTFMode implements GameModeHandler {
       player.maxHealth = player.maxHealth ?? this.DEFAULT_MAX_HEALTH;
       player.health = player.maxHealth;
       player.respawnAt = undefined;
+      player.currentKillStreak = 0;
       i++;
     });
   }
@@ -84,6 +87,13 @@ export class CTFMode implements GameModeHandler {
         player.spawnProtectedUntil = undefined;
       }
     });
+
+    if (
+      gameState.streakAnnouncement !== undefined &&
+      now >= gameState.streakAnnouncement.timestamp + STREAK_ANNOUNCE_MS
+    ) {
+      gameState.streakAnnouncement = undefined;
+    }
   }
 
   onAction(
@@ -133,33 +143,99 @@ export class CTFMode implements GameModeHandler {
     target.health = Math.max(0, currentHealth - damage);
 
     if (target.health === 0) {
-      target.respawnAt = Date.now() + this.RESPAWN_DELAY_MS;
+      this.applyDown(
+        attackerId,
+        targetId,
+        weaponId,
+        attacker,
+        target,
+        gameState,
+      );
+    }
 
-      // A downed carrier drops the flag back at its base rather than
-      // letting it sit on a player who's now out of the round.
-      gameState.flags?.forEach((flag) => {
-        if (flag.carrierId === targetId) {
-          flag.carrierId = undefined;
-          flag.position = [...flag.basePosition];
+    // Rocket splash: deal splash damage to bystanders within splashRadius of the target
+    const weaponDef = weaponId ? WEAPONS[weaponId] : undefined;
+    if (weaponDef?.splashRadius && weaponDef.splashDamage) {
+      const { splashRadius, splashDamage } = weaponDef;
+      players.forEach((nearby, nearbyId) => {
+        if (nearbyId === attackerId || nearbyId === targetId) return;
+        if (nearby.respawnAt !== undefined) return;
+        if (
+          nearby.spawnProtectedUntil !== undefined &&
+          Date.now() < nearby.spawnProtectedUntil
+        )
+          return;
+        const dx = target.position[0] - nearby.position[0];
+        const dy = target.position[1] - nearby.position[1];
+        const dz = target.position[2] - nearby.position[2];
+        if (Math.sqrt(dx * dx + dy * dy + dz * dz) > splashRadius) return;
+
+        const nearbyMax = nearby.maxHealth ?? this.DEFAULT_MAX_HEALTH;
+        nearby.health = Math.max(
+          0,
+          (nearby.health ?? nearbyMax) - splashDamage,
+        );
+        if (nearby.health === 0) {
+          this.applyDown(
+            attackerId,
+            nearbyId,
+            weaponId,
+            attacker,
+            nearby,
+            gameState,
+          );
         }
       });
-
-      log.debug(`${attacker.name} downed ${target.name}!`);
-
-      const killEvent: KillEvent = {
-        killerId: attackerId,
-        killerName: attacker.name,
-        targetId,
-        targetName: target.name,
-        weaponId: weaponId ?? "unknown",
-        timestamp: Date.now(),
-      };
-      if (!gameState.killFeed) gameState.killFeed = [];
-      gameState.killFeed.push(killEvent);
-      if (gameState.killFeed.length > 10) gameState.killFeed.shift();
     }
 
     return true;
+  }
+
+  private applyDown(
+    attackerId: string,
+    targetId: string,
+    weaponId: string | undefined,
+    attacker: Player,
+    target: Player,
+    gameState: GameState,
+  ): void {
+    target.respawnAt = Date.now() + this.RESPAWN_DELAY_MS;
+
+    // A downed carrier drops the flag back at its base.
+    gameState.flags?.forEach((flag) => {
+      if (flag.carrierId === targetId) {
+        flag.carrierId = undefined;
+        flag.position = [...flag.basePosition];
+      }
+    });
+
+    attacker.currentKillStreak = (attacker.currentKillStreak ?? 0) + 1;
+    target.currentKillStreak = 0;
+
+    const streak = attacker.currentKillStreak;
+    if ((STREAK_THRESHOLDS as readonly number[]).includes(streak)) {
+      gameState.streakAnnouncement = {
+        killerName: attacker.name,
+        count: streak,
+        timestamp: Date.now(),
+      };
+    }
+
+    log.debug(
+      `${attacker.name} downed ${target.name}! (streak: ${attacker.currentKillStreak})`,
+    );
+
+    const killEvent: KillEvent = {
+      killerId: attackerId,
+      killerName: attacker.name,
+      targetId,
+      targetName: target.name,
+      weaponId: weaponId ?? "unknown",
+      timestamp: Date.now(),
+    };
+    if (!gameState.killFeed) gameState.killFeed = [];
+    gameState.killFeed.push(killEvent);
+    if (gameState.killFeed.length > 10) gameState.killFeed.shift();
   }
 
   private pickupFlag(
@@ -243,7 +319,10 @@ export class CTFMode implements GameModeHandler {
       player.health = player.maxHealth;
       player.respawnAt = undefined;
       player.spawnProtectedUntil = undefined;
+      player.currentKillStreak = 0;
     });
+
+    gameState.streakAnnouncement = undefined;
 
     return results;
   }

--- a/src/components/gameModes/DeathmatchMode.ts
+++ b/src/components/gameModes/DeathmatchMode.ts
@@ -222,4 +222,4 @@ export class DeathmatchMode implements GameModeHandler {
 
 export default DeathmatchMode;
 
-export { STREAK_LABELS };
+export { STREAK_LABELS, STREAK_THRESHOLDS, STREAK_ANNOUNCE_MS };

--- a/src/pages/Solo/components/Bots.tsx
+++ b/src/pages/Solo/components/Bots.tsx
@@ -184,7 +184,7 @@ const Bots: React.FC<
   }, [gameManager, bot2IsIt, bot1IsIt, setBot1GotTagged]);
 
   // Each bot gets its own WeaponManager so they can use different weapons.
-  // Bot-1 uses the Pulse Shotgun (close-range burst); bot-2 uses the Laser Blaster.
+  // Bot-1 uses the Pulse Shotgun (close-range burst); bot-2 uses the Rocket Launcher.
   const bot1WeaponsRef = useRef<WeaponManager | null>(null);
   const bot2WeaponsRef = useRef<WeaponManager | null>(null);
 
@@ -202,7 +202,7 @@ const Bots: React.FC<
       const weaponRef = isBot1 ? bot1WeaponsRef : bot2WeaponsRef;
       if (!weaponRef.current) {
         weaponRef.current = new WeaponManager();
-        weaponRef.current.equip(isBot1 ? "shotgun" : "laser");
+        weaponRef.current.equip(isBot1 ? "shotgun" : "rocket");
       }
 
       const weapon = weaponRef.current.fire(botId);


### PR DESCRIPTION
## Summary
- **CTFMode kill streaks**: downing 3/5/7/10 enemies in a row now triggers KILLING SPREE / RAMPAGE / UNSTOPPABLE / GODLIKE announcement (shared constants from DeathmatchMode, same golden banner in GameUI already handles CTF)
- **CTFMode rocket splash**: bystanders within 5u of the impact point take 50 splash damage when a rocket is fired in CTF — mirrors DeathmatchMode behaviour
- **Bot-2 upgraded to Rocket Launcher**: was laser (infinite ammo, 10dmg); now starts with rocket (3 shots, 100dmg + splash), falls back to laser on empty — much more arena chaos

## Test plan
- [ ] 3 new tests in `gameManager.ctf.test.ts`: streak announcement on 3rd kill, streak reset on death, rocket splash bystander damage
- [ ] All 482 tests pass (69 files), 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)