### PR TITLE
Phase R: Frag Grenade — key 4, 100dmg, 7u splash radius, 2 shots

### DIFF
--- a/src/__tests__/gameManager.deathmatch.test.ts
+++ b/src/__tests__/gameManager.deathmatch.test.ts
@@ -335,6 +335,33 @@ describe("GameManager deathmatch", () => {
     expect(p1.currentKillStreak).toBe(2);
   });
 
+  it("grenade splash (radius 7) damages all bystanders in range and awards kills", () => {
+    const makeP = (id: string, pos: [number, number, number]): Player => ({
+      id,
+      name: id,
+      position: pos,
+      rotation: [0, 0, 0],
+    });
+
+    const manager = new GameManager();
+    manager.addPlayer(makeP("p1", [0, 0, 0])); // attacker
+    manager.addPlayer(makeP("p2", [3, 0, 0])); // direct target
+    manager.addPlayer(makeP("p3", [5, 0, 0])); // 2u from p2 → within splashRadius 7
+    manager.addPlayer(makeP("p4", [20, 0, 0])); // far — out of range
+
+    vi.spyOn(Date, "now").mockReturnValue(10000);
+    manager.startDeathmatchGame(120, 10);
+
+    // grenade: 100 dmg direct, splashRadius 7, splashDamage 75
+    manager.hitPlayer("p1", "p2", 100, "grenade");
+
+    const players = manager.getPlayers();
+    expect(players.get("p2")?.health).toBe(0); // direct kill
+    expect(players.get("p3")?.health).toBe(25); // 100 - 75 splash
+    expect(players.get("p4")?.health).toBe(100); // out of range
+    expect(manager.getGameState().scores["p1"]).toBe(1); // direct kill credited
+  });
+
   it("ends the game once a player reaches the kill limit, with results sorted by kills", () => {
     const manager = new GameManager();
     manager.addPlayer(makePlayer("p1", "P1"));

--- a/src/components/characters/PlayerCharacter.tsx
+++ b/src/components/characters/PlayerCharacter.tsx
@@ -5,7 +5,20 @@ import { Socket } from "socket.io-client";
 import * as THREE from "three";
 import type { Clients } from "../../types/socket";
 import GameManager, { GameState } from "../GameManager";
-import { W, A, S, D, Q, E, SHIFT, SPACE, KEY_1, KEY_2, KEY_3 } from "../utils";
+import {
+  W,
+  A,
+  S,
+  D,
+  Q,
+  E,
+  SHIFT,
+  SPACE,
+  KEY_1,
+  KEY_2,
+  KEY_3,
+  KEY_4,
+} from "../utils";
 import SpacemanModel from "../SpacemanModel";
 import { getSoundManager } from "../SoundManager";
 import { WeaponManager } from "../combat/WeaponManager";
@@ -157,6 +170,7 @@ export const PlayerCharacter = React.forwardRef<
   const prevKey1Ref = React.useRef(false);
   const prevKey2Ref = React.useRef(false);
   const prevKey3Ref = React.useRef(false);
+  const prevKey4Ref = React.useRef(false);
 
   // Equip the laser blaster by default and surface the equipped weapon to the HUD.
   React.useEffect(() => {
@@ -426,10 +440,11 @@ export const PlayerCharacter = React.forwardRef<
       }
     }
 
-    // Weapon switching: rising-edge detection for 1 (laser), 2 (shotgun), 3 (rocket).
+    // Weapon switching: rising-edge detection for 1 (laser), 2 (shotgun), 3 (rocket), 4 (grenade).
     const key1 = keysPressedRef.current[KEY_1] ?? false;
     const key2 = keysPressedRef.current[KEY_2] ?? false;
     const key3 = keysPressedRef.current[KEY_3] ?? false;
+    const key4 = keysPressedRef.current[KEY_4] ?? false;
     const myId = socketClient?.id || currentPlayerId;
     if (key1 && !prevKey1Ref.current) {
       weaponManagerRef.current.equip("laser");
@@ -452,9 +467,17 @@ export const PlayerCharacter = React.forwardRef<
         currentAmmo: weaponManagerRef.current.getAmmo("rocket"),
       });
     }
+    if (key4 && !prevKey4Ref.current) {
+      weaponManagerRef.current.equip("grenade");
+      gameManager?.updatePlayer(myId, {
+        equippedWeaponId: "grenade",
+        currentAmmo: weaponManagerRef.current.getAmmo("grenade"),
+      });
+    }
     prevKey1Ref.current = key1;
     prevKey2Ref.current = key2;
     prevKey3Ref.current = key3;
+    prevKey4Ref.current = key4;
 
     // Fire the equipped weapon while left-click is held (rate-limited by
     // WeaponManager's per-shooter cooldown).
@@ -482,13 +505,19 @@ export const PlayerCharacter = React.forwardRef<
         const beamLength = fireResult.hit?.distance ?? fireResult.weapon.range;
         const wid = fireResult.weapon.id;
         const beamHalfWidth =
-          wid === "rocket" ? 0.2 : wid === "shotgun" ? 0.1 : 0.04;
+          wid === "rocket" || wid === "grenade"
+            ? 0.2
+            : wid === "shotgun"
+              ? 0.1
+              : 0.04;
         const beamColor =
           wid === "rocket"
             ? "#ff1100"
-            : wid === "shotgun"
-              ? "#ff7700"
-              : "#33ffe6";
+            : wid === "grenade"
+              ? "#44ff00"
+              : wid === "shotgun"
+                ? "#ff7700"
+                : "#33ffe6";
         laserBeamRef.current.visible = true;
         laserBeamRef.current.position
           .copy(fireOrigin)

--- a/src/components/combat/WeaponManager.ts
+++ b/src/components/combat/WeaponManager.ts
@@ -39,6 +39,16 @@ export const WEAPONS: Record<string, WeaponConfig> = {
     splashRadius: 5,
     splashDamage: 50,
   },
+  grenade: {
+    id: "grenade",
+    name: "Frag Grenade",
+    damage: 100,
+    range: 18,
+    cooldownMs: 4000,
+    maxAmmo: 2,
+    splashRadius: 7,
+    splashDamage: 75,
+  },
 };
 
 /**

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -9,6 +9,7 @@ export const SPACE = " ";
 export const KEY_1 = "1";
 export const KEY_2 = "2";
 export const KEY_3 = "3";
+export const KEY_4 = "4";
 export const DIRECTIONS = [W, A, S, D, Q, E];
 
 export class KeyDisplay {

--- a/src/components/world/WeaponPickups.tsx
+++ b/src/components/world/WeaponPickups.tsx
@@ -41,6 +41,12 @@ export const PICKUP_DEFS: PickupDef[] = [
     weaponId: "rocket",
     color: "#ff1100",
   },
+  {
+    id: "pickup-grenade",
+    position: [0, 0.8, 14],
+    weaponId: "grenade",
+    color: "#44ff00",
+  },
 ];
 
 type PickupState = {

--- a/src/components/world/__tests__/WeaponPickups.test.ts
+++ b/src/components/world/__tests__/WeaponPickups.test.ts
@@ -14,6 +14,7 @@ describe("WeaponPickups pickup definitions", () => {
     expect(weaponIds.has("laser")).toBe(true);
     expect(weaponIds.has("shotgun")).toBe(true);
     expect(weaponIds.has("rocket")).toBe(true);
+    expect(weaponIds.has("grenade")).toBe(true);
   });
 
   it("pickup positions have non-negative Y (above ground)", () => {


### PR DESCRIPTION
## Summary
- **New weapon: Frag Grenade** (key 4): 100 direct damage, 7-unit splash radius, 75 splash damage, 2 shots, 4s cooldown — larger AoE than the rocket but slower fire rate
- **Grenade pickup crate** at `[0, 0.8, 14]` (opposite the rocket crate) with green glow color
- **Green beam visual** when throwing — distinct from red (rocket), orange (shotgun), cyan (laser)
- Splash handled automatically by existing DeathmatchMode + CTFMode splash logic via WEAPONS registry

## Test plan
- [ ] `grenade splash (radius 7) damages all bystanders in range and awards kills` in `gameManager.deathmatch.test.ts`
- [ ] WeaponPickups test updated to expect grenade pickup in PICKUP_DEFS
- [ ] All 483 tests pass (69 files), 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)