### PR TITLE
Phase T: laser tag — IT player fires laser to transfer tag from range

### DIFF
--- a/src/__tests__/gameManager.core.test.ts
+++ b/src/__tests__/gameManager.core.test.ts
@@ -111,4 +111,44 @@ describe("GameManager core", () => {
     expect(manager.getGameState().isActive).toBe(false);
     expect(manager.getGameState().timeRemaining).toBe(0);
   });
+
+  it("laser-tag: a hit from the IT player transfers IT status (ranged tag)", () => {
+    vi.spyOn(Date, "now").mockReturnValue(0);
+    vi.spyOn(Math, "random").mockReturnValue(0); // p1 becomes IT
+
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "Player 1"));
+    manager.addPlayer(makePlayer("p2", "Player 2"));
+    manager.startTagGame(60);
+
+    expect(manager.getPlayers().get("p1")?.isIt).toBe(true);
+
+    // p1 (IT) fires laser and hits p2
+    vi.spyOn(Date, "now").mockReturnValue(5000);
+    const result = manager.hitPlayer("p1", "p2", 10, "laser");
+
+    expect(result).toBe(true);
+    expect(manager.getPlayers().get("p1")?.isIt).toBe(false);
+    expect(manager.getPlayers().get("p2")?.isIt).toBe(true);
+    expect(manager.getGameState().itPlayerId).toBe("p2");
+    // No health damage in tag mode
+    expect(manager.getPlayers().get("p2")?.health).toBeUndefined();
+  });
+
+  it("laser-tag: a hit from a non-IT player does nothing in tag mode", () => {
+    vi.spyOn(Date, "now").mockReturnValue(0);
+    vi.spyOn(Math, "random").mockReturnValue(0); // p1 becomes IT
+
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "Player 1"));
+    manager.addPlayer(makePlayer("p2", "Player 2"));
+    manager.startTagGame(60);
+
+    // p2 (not IT) fires at p1 — should not transfer IT
+    const result = manager.hitPlayer("p2", "p1", 10, "laser");
+
+    expect(result).toBe(false);
+    expect(manager.getPlayers().get("p1")?.isIt).toBe(true);
+    expect(manager.getPlayers().get("p2")?.isIt).toBe(false);
+  });
 });

--- a/src/__tests__/gameManager.deathmatch.test.ts
+++ b/src/__tests__/gameManager.deathmatch.test.ts
@@ -90,16 +90,12 @@ describe("GameManager deathmatch", () => {
     expect(manager.hitPlayer("p1", "p1", 10)).toBe(false);
   });
 
-  it("rejects hits outside an active deathmatch", () => {
+  it("rejects hits when no game is active", () => {
     const manager = new GameManager();
     manager.addPlayer(makePlayer("p1", "P1"));
     manager.addPlayer(makePlayer("p2", "P2"));
 
-    // Not started yet
-    expect(manager.hitPlayer("p1", "p2", 10)).toBe(false);
-
-    // Started in tag mode instead
-    manager.startTagGame();
+    // Not started yet (mode = "none", isActive = false)
     expect(manager.hitPlayer("p1", "p2", 10)).toBe(false);
   });
 

--- a/src/components/GameManager.ts
+++ b/src/components/GameManager.ts
@@ -242,7 +242,9 @@ export class GameManager {
     weaponId?: string,
   ): boolean {
     if (
-      (this.gameState.mode !== "deathmatch" && this.gameState.mode !== "ctf") ||
+      (this.gameState.mode !== "deathmatch" &&
+        this.gameState.mode !== "ctf" &&
+        this.gameState.mode !== "tag") ||
       !this.gameState.isActive
     ) {
       return false;

--- a/src/components/gameModes/TagMode.ts
+++ b/src/components/gameModes/TagMode.ts
@@ -51,6 +51,11 @@ export class TagMode implements GameModeHandler {
     players: Map<string, Player>,
     gameState: GameState,
   ): boolean {
+    // A laser "hit" in tag mode works as a ranged tag — no health damage, just IT transfer.
+    if (action.type === "hit") {
+      const { attackerId, targetId } = action;
+      return this.applyTag(attackerId, targetId, players, gameState);
+    }
     if (action.type !== "tag") return false;
     const { taggerId, taggedId } = action;
 
@@ -58,6 +63,15 @@ export class TagMode implements GameModeHandler {
       `[TAG-TRACE] tagPlayer called with taggerId=${taggerId}, taggedId=${taggedId}`,
     );
 
+    return this.applyTag(taggerId, taggedId, players, gameState);
+  }
+
+  private applyTag(
+    taggerId: string,
+    taggedId: string,
+    players: Map<string, Player>,
+    gameState: GameState,
+  ): boolean {
     const tagger = players.get(taggerId);
     const tagged = players.get(taggedId);
 

--- a/src/lib/hooks/__tests__/usePlayerWeapon.test.ts
+++ b/src/lib/hooks/__tests__/usePlayerWeapon.test.ts
@@ -90,8 +90,9 @@ describe("usePlayerWeapon.processFiring", () => {
     expect(gameManager.getPlayers().get("target")?.health).toBeUndefined();
   });
 
-  it("fires, hits a target, and applies damage", () => {
+  it("fires, hits a target, and applies damage in deathmatch", () => {
     weaponManager.equip("laser");
+    gameManager.startDeathmatchGame(120, 5);
 
     const result = processFiring({
       origin,
@@ -112,9 +113,10 @@ describe("usePlayerWeapon.processFiring", () => {
     expect(target?.health).toBe(90);
   });
 
-  it("clamps health at 0 instead of going negative", () => {
+  it("clamps health at 0 instead of going negative in deathmatch", () => {
     weaponManager.equip("laser");
-    gameManager.updatePlayer("target", { health: 5, maxHealth: 100 });
+    gameManager.startDeathmatchGame(120, 5);
+    gameManager.updatePlayer("target", { health: 5 });
 
     const result = processFiring({
       origin,

--- a/src/lib/hooks/usePlayerWeapon.ts
+++ b/src/lib/hooks/usePlayerWeapon.ts
@@ -10,8 +10,6 @@ import type {
 } from "../../components/combat/WeaponManager";
 import { getSoundManager } from "../../components/SoundManager";
 
-const DEFAULT_MAX_HEALTH = 100;
-
 export interface FireParams {
   origin: THREE.Vector3;
   direction: THREE.Vector3;
@@ -70,32 +68,16 @@ export function processFiring(params: FireParams): FireResult | null {
     const gameState = gameManager.getGameState();
     let damageApplied = false;
 
-    if (
-      (gameState.mode === "deathmatch" || gameState.mode === "ctf") &&
-      gameState.isActive
-    ) {
-      // Deathmatch/CTF: the active mode applies damage and starts respawn
-      // timers (and, in CTF, drops any carried flag). Rejected hits (e.g. a
-      // downed target) deal no damage.
-      // Splash damage for rocket-type weapons is handled inside DeathmatchMode/CTFMode
-      // onAction, which has access to all player positions via the players Map.
+    if (gameState.isActive) {
+      // Route all hits through the active game mode's onAction handler.
+      // DeathmatchMode/CTFMode apply health/respawn; TagMode treats a hit
+      // from the IT player as a ranged tag (no health damage).
       damageApplied = gameManager.hitPlayer(
         shooterId,
         hit.hitPlayerId,
         weapon.damage,
         weapon.id,
       );
-    } else {
-      const target = gameManager.getPlayers().get(hit.hitPlayerId);
-      if (target) {
-        const maxHealth = target.maxHealth ?? DEFAULT_MAX_HEALTH;
-        const currentHealth = target.health ?? maxHealth;
-        gameManager.updatePlayer(hit.hitPlayerId, {
-          maxHealth,
-          health: Math.max(0, currentHealth - weapon.damage),
-        });
-        damageApplied = true;
-      }
     }
 
     if (damageApplied) {

--- a/src/pages/Solo/components/Bots.tsx
+++ b/src/pages/Solo/components/Bots.tsx
@@ -209,12 +209,18 @@ const Bots: React.FC<
 
   const fireBotWeapon = useCallback(
     (botId: string, targetId: string) => {
-      if (
-        !gameManager ||
-        (gameState.mode !== "deathmatch" && gameState.mode !== "ctf") ||
-        !gameState.isActive
-      ) {
-        return;
+      if (!gameManager || !gameState.isActive) return;
+
+      const isTagMode = gameState.mode === "tag";
+      const isCombatMode =
+        gameState.mode === "deathmatch" || gameState.mode === "ctf";
+
+      if (!isTagMode && !isCombatMode) return;
+
+      // In tag mode only the IT bot fires (the laser acts as a ranged tag).
+      if (isTagMode) {
+        const botPlayer = gameManager.getPlayers().get(botId);
+        if (!botPlayer?.isIt) return;
       }
 
       const weaponRef =
@@ -225,8 +231,9 @@ const Bots: React.FC<
             : bot3WeaponsRef;
       if (!weaponRef.current) {
         weaponRef.current = new WeaponManager();
-        const startWeapon =
-          botId === "bot-1"
+        const startWeapon = isTagMode
+          ? "laser"
+          : botId === "bot-1"
             ? "shotgun"
             : botId === "bot-2"
               ? "rocket"


### PR DESCRIPTION
## Summary
- **Laser tag mechanic**: in tag mode, a `{type:"hit"}` action on the IT player's laser shot now transfers the IT role to the target (no health damage — pure tag transfer)
- `TagMode.onAction` handles `"hit"` actions, delegating to the shared `applyTag()` private method (same cooldowns as proximity tag)
- `GameManager.hitPlayer` now allows `mode === "tag"` alongside deathmatch/ctf
- `Bots.tsx`: IT bots now fire their laser at the target in tag mode (non-IT bots keep their guns sheathed)
- `usePlayerWeapon.processFiring`: simplified — all hits in any active game mode route through `gameManager.hitPlayer` (TagMode/DeathmatchMode/CTFMode each handle the action accordingly)

## Test plan
- [ ] 485 tests passing, 5 skipped — green
- [ ] ESLint clean (pre-commit hook passed)
- [ ] New tests: "laser-tag: a hit from the IT player transfers IT status" + "a hit from a non-IT player does nothing"
- [ ] Start tag game → fire laser while IT → bot target becomes IT
- [ ] Bot that is IT fires laser → player becomes IT

🤖 Generated with [Claude Code](https://claude.com/claude-code)