### PR TITLE
Phase U: weapon pickups active in tag mode — power weapons for ranged tagging

### DIFF
--- a/src/__tests__/gameManager.ctf.test.ts
+++ b/src/__tests__/gameManager.ctf.test.ts
@@ -243,16 +243,12 @@ describe("GameManager CTF", () => {
     expect(manager.hitPlayer("p1", "p2", 10)).toBe(false);
   });
 
-  it("rejects hits outside an active CTF game", () => {
+  it("rejects hits when no game is active", () => {
     const manager = new GameManager();
     manager.addPlayer(makePlayer("p1", "P1"));
     manager.addPlayer(makePlayer("p2", "P2"));
 
-    // Not started yet
-    expect(manager.hitPlayer("p1", "p2", 10)).toBe(false);
-
-    // Started in tag mode instead
-    manager.startTagGame();
+    // Not started yet (mode = "none", isActive = false)
     expect(manager.hitPlayer("p1", "p2", 10)).toBe(false);
   });
 

--- a/src/components/world/WeaponPickups.tsx
+++ b/src/components/world/WeaponPickups.tsx
@@ -73,7 +73,9 @@ const WeaponPickups: React.FC<WeaponPickupsProps> = ({
   useFrame((_, delta) => {
     const isActive =
       gameState.isActive &&
-      (gameState.mode === "deathmatch" || gameState.mode === "ctf");
+      (gameState.mode === "deathmatch" ||
+        gameState.mode === "ctf" ||
+        gameState.mode === "tag");
 
     if (!isActive) {
       groupRefs.current.forEach((g) => {


### PR DESCRIPTION
## Summary
- Weapon pickup crates now appear during tag games (previously deathmatch/CTF only)
- The IT player can grab a shotgun, rocket, or grenade to fire a more powerful ranged tag shot (all hit types route through TagMode.onAction as ranged tags)
- Non-IT players can also pick up weapons but their shots have no effect (TagMode rejects hits from non-IT players)
- Updated the "rejects hits outside active game" test in CTF suite to not assert on tag mode (tag mode now accepts hits)

## Test plan
- [ ] 485 tests passing, 5 skipped — green
- [ ] ESLint clean
- [ ] Start tag game → weapon crates appear on the map
- [ ] Grab rocket as IT → fire at bot → IT transfers with splash

🤖 Generated with [Claude Code](https://claude.com/claude-code)