### PR TITLE
Phase W: tag events in kill feed — running icon + 'tagged' verb

### DIFF
--- a/src/__tests__/gameManager.core.test.ts
+++ b/src/__tests__/gameManager.core.test.ts
@@ -135,6 +135,25 @@ describe("GameManager core", () => {
     expect(manager.getPlayers().get("p2")?.health).toBeUndefined();
   });
 
+  it("tag event is pushed to killFeed on a successful tag", () => {
+    vi.spyOn(Date, "now").mockReturnValue(0);
+    vi.spyOn(Math, "random").mockReturnValue(0); // p1 becomes IT
+
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "Player 1"));
+    manager.addPlayer(makePlayer("p2", "Player 2"));
+    manager.startTagGame(60);
+
+    vi.spyOn(Date, "now").mockReturnValue(5000);
+    manager.tagPlayer("p1", "p2");
+
+    const feed = manager.getGameState().killFeed ?? [];
+    expect(feed).toHaveLength(1);
+    expect(feed[0].killerId).toBe("p1");
+    expect(feed[0].targetId).toBe("p2");
+    expect(feed[0].weaponId).toBe("tag");
+  });
+
   it("laser-tag: a hit from a non-IT player does nothing in tag mode", () => {
     vi.spyOn(Date, "now").mockReturnValue(0);
     vi.spyOn(Math, "random").mockReturnValue(0); // p1 becomes IT

--- a/src/components/GameUI.tsx
+++ b/src/components/GameUI.tsx
@@ -398,11 +398,21 @@ const GameUI: React.FC<GameUIProps> = ({
                   color: "#ffdd88",
                 }}
               >
-                💀 {k.killerName}{" "}
-                <span style={{ color: "#aaaaaa" }}>
-                  [{WEAPONS[k.weaponId]?.name ?? k.weaponId}]
-                </span>{" "}
-                → {k.targetName}
+                {k.weaponId === "tag" ? (
+                  <>
+                    🏃 {k.killerName}{" "}
+                    <span style={{ color: "#aaaaaa" }}>tagged</span>{" "}
+                    {k.targetName}
+                  </>
+                ) : (
+                  <>
+                    💀 {k.killerName}{" "}
+                    <span style={{ color: "#aaaaaa" }}>
+                      [{WEAPONS[k.weaponId]?.name ?? k.weaponId}]
+                    </span>{" "}
+                    → {k.targetName}
+                  </>
+                )}
               </div>
             ))}
           </div>

--- a/src/components/gameModes/TagMode.ts
+++ b/src/components/gameModes/TagMode.ts
@@ -1,5 +1,5 @@
 import { createLogger } from "../../lib/utils/logger";
-import type { GameState, Player } from "../GameManager";
+import type { GameState, KillEvent, Player } from "../GameManager";
 import type {
   GameAction,
   GameModeHandler,
@@ -28,6 +28,7 @@ export class TagMode implements GameModeHandler {
   onStart(players: Map<string, Player>, gameState: GameState): void {
     const itPlayerId = this.pickRandomPlayer(players);
     gameState.itPlayerId = itPlayerId;
+    gameState.killFeed = [];
 
     players.forEach((player, id) => {
       gameState.scores[id] = 0;
@@ -125,6 +126,18 @@ export class TagMode implements GameModeHandler {
     gameState.itPlayerId = taggedId;
     gameState.roundStartTime = now;
 
+    const tagEvent: KillEvent = {
+      killerId: taggerId,
+      killerName: tagger.name,
+      targetId: taggedId,
+      targetName: tagged.name,
+      weaponId: "tag",
+      timestamp: now,
+    };
+    if (!gameState.killFeed) gameState.killFeed = [];
+    gameState.killFeed.push(tagEvent);
+    if (gameState.killFeed.length > 20) gameState.killFeed.shift();
+
     log.debug(
       `${tagger.name} tagged ${tagged.name}! ${tagged.name} is now IT!`,
     );
@@ -169,6 +182,7 @@ export class TagMode implements GameModeHandler {
       player.lastTaggedById = undefined;
     });
 
+    gameState.killFeed = undefined;
     return results;
   }
 


### PR DESCRIPTION
## Summary
- `TagMode.onStart` initialises `gameState.killFeed = []`
- `TagMode.applyTag` pushes a `KillEvent` with `weaponId: "tag"` on each successful tag
- `GameUI` renders kill feed entries with `weaponId === "tag"` as "🏃 X tagged Y" (running icon, 'tagged' verb) vs the regular "💀 X [weapon] → Y"
- `TagMode.onEnd` clears `killFeed` on game end

## Test plan
- [ ] 486 tests passing, 5 skipped — green
- [ ] New test: "tag event is pushed to killFeed on a successful tag"
- [ ] Start tag game → tag a bot → see "🏃 Player tagged Bot1" in bottom-left feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)