### PR TITLE
Phase X: bots teleport back to spawn on respawn

### DIFF
--- a/src/components/characters/useBotAI.ts
+++ b/src/components/characters/useBotAI.ts
@@ -109,6 +109,17 @@ export function useBotAI({
   const sprintEndTime = useRef(0);
   const nextSprintTime = useRef(0);
 
+  // Teleport bot back to spawn when it respawns after being downed.
+  const prevIsDownedRef = useRef(isDowned);
+  useEffect(() => {
+    if (prevIsDownedRef.current && !isDowned && meshRef.current) {
+      meshRef.current.position.set(...config.initialPosition);
+      lastPosition.current.set(...config.initialPosition);
+      lastReportedPosition.current.set(...config.initialPosition);
+    }
+    prevIsDownedRef.current = isDowned;
+  }, [isDowned, config.initialPosition, meshRef]);
+
   // Handle being tagged by target
   useEffect(() => {
     if (


### PR DESCRIPTION
## Summary
- `useBotAI` now detects the `isDowned: true → false` transition via a `prevIsDownedRef`
- On respawn, teleports the bot mesh back to `config.initialPosition` and resets internal position tracking refs
- Bots rejoin the fight from their designated spawn point instead of lingering at their death location

## Test plan
- [ ] 486 tests passing, 5 skipped — green
- [ ] ESLint clean
- [ ] Start deathmatch → kill a bot → wait for respawn timer → bot reappears at its original spawn position

🤖 Generated with [Claude Code](https://claude.com/claude-code)