### PR TITLE
Phase Y: bots refill specialty weapon on ammo depletion

### DIFF
--- a/src/pages/Solo/components/Bots.tsx
+++ b/src/pages/Solo/components/Bots.tsx
@@ -243,12 +243,13 @@ const Bots: React.FC<
 
       const weapon = weaponRef.current.fire(botId);
       if (!weapon) {
-        // If ammo is depleted (not just on cooldown), fall back to infinite laser.
+        // If ammo is depleted (not just on cooldown), refill and keep the
+        // specialty weapon so bots remain a persistent threat throughout the round.
         const equipped = weaponRef.current.getEquipped();
         if (equipped) {
           const ammo = weaponRef.current.getAmmo(equipped.id);
           if (ammo !== null && ammo <= 0) {
-            weaponRef.current.equip("laser");
+            weaponRef.current.refillAmmo(equipped.id);
           }
         }
         return;


### PR DESCRIPTION
## Summary
- When bot ammo reaches 0, `refillAmmo(equipped.id)` is called instead of falling back to laser
- Bot-2 (rocket) and Bot-3 (grenade) remain persistent threats rather than degrading to laser mid-round
- In tag mode this is a no-op since bots use laser (infinite ammo) anyway

## Test plan
- [ ] 486 tests passing, 5 skipped — green
- [ ] ESLint clean
- [ ] Start deathmatch → play for full duration → bots continue firing rockets/grenades the whole round

🤖 Generated with [Claude Code](https://claude.com/claude-code)