### PR TITLE
Phase Z: tag streak announcements — ON A ROLL / TAGGING SPREE / UNTOUCHABLE / TAG GOD

### DIFF
--- a/src/__tests__/gameManager.core.test.ts
+++ b/src/__tests__/gameManager.core.test.ts
@@ -170,4 +170,46 @@ describe("GameManager core", () => {
     expect(manager.getPlayers().get("p1")?.isIt).toBe(true);
     expect(manager.getPlayers().get("p2")?.isIt).toBe(false);
   });
+
+  it("tag streak: 3 cumulative tags by the same player trigger a streak announcement", () => {
+    // p1 starts IT. Each time p1 escapes IT (tags someone), tally increments.
+    // Getting re-tagged doesn't reset the tally, so milestone=3 is reachable.
+    vi.spyOn(Math, "random").mockReturnValue(0); // p1 starts IT
+    vi.spyOn(Date, "now").mockReturnValue(0);
+
+    const manager = new GameManager();
+    manager.addPlayer(makePlayer("p1", "Player 1"));
+    manager.addPlayer(makePlayer("p2", "Player 2"));
+    manager.addPlayer(makePlayer("p3", "Player 3"));
+    manager.startTagGame(120);
+
+    expect(manager.getPlayers().get("p1")?.isIt).toBe(true);
+
+    // p1 tags p2 (tally=1), p2 tags p3, p3 tags p1 (p1 is IT again, tally unchanged)
+    vi.spyOn(Date, "now").mockReturnValue(5000);
+    manager.tagPlayer("p1", "p2"); // p1 tally=1
+
+    vi.spyOn(Date, "now").mockReturnValue(8000);
+    manager.tagPlayer("p2", "p3");
+
+    vi.spyOn(Date, "now").mockReturnValue(11000);
+    manager.tagPlayer("p3", "p1"); // p1 is IT again, tally stays 1
+
+    vi.spyOn(Date, "now").mockReturnValue(14000);
+    manager.tagPlayer("p1", "p2"); // p1 tally=2
+
+    vi.spyOn(Date, "now").mockReturnValue(17000);
+    manager.tagPlayer("p2", "p3");
+
+    vi.spyOn(Date, "now").mockReturnValue(20000);
+    manager.tagPlayer("p3", "p1"); // p1 is IT again, tally stays 2
+
+    vi.spyOn(Date, "now").mockReturnValue(23000);
+    manager.tagPlayer("p1", "p2"); // p1 tally=3 → streakAnnouncement fires
+
+    const ann = manager.getGameState().streakAnnouncement;
+    expect(ann).toBeDefined();
+    expect(ann?.killerName).toBe("Player 1");
+    expect(ann?.count).toBe(3);
+  });
 });

--- a/src/components/GameUI.tsx
+++ b/src/components/GameUI.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { GameState, KillEvent, Player } from "./GameManager";
 import { WEAPONS } from "./combat/WeaponManager";
 import { STREAK_LABELS } from "./gameModes/DeathmatchMode";
+import { TAG_STREAK_LABELS } from "./gameModes/TagMode";
 
 interface GameUIProps {
   gameState: GameState;
@@ -608,7 +609,9 @@ const GameUI: React.FC<GameUIProps> = ({
           )}
 
         {visibleStreak !== null &&
-          (gameState.mode === "deathmatch" || gameState.mode === "ctf") && (
+          (gameState.mode === "deathmatch" ||
+            gameState.mode === "ctf" ||
+            gameState.mode === "tag") && (
             <div
               style={{
                 position: "fixed",
@@ -625,13 +628,19 @@ const GameUI: React.FC<GameUIProps> = ({
                   fontFamily: "monospace",
                   fontSize: isMinimal ? "14px" : "26px",
                   fontWeight: "bold",
-                  color: "#ffcc00",
-                  textShadow: "0 0 18px #ff8800, 0 0 6px #ffcc00",
+                  color: gameState.mode === "tag" ? "#00ffff" : "#ffcc00",
+                  textShadow:
+                    gameState.mode === "tag"
+                      ? "0 0 18px #0088ff, 0 0 6px #00ffff"
+                      : "0 0 18px #ff8800, 0 0 6px #ffcc00",
                   letterSpacing: "3px",
                 }}
               >
-                {STREAK_LABELS[visibleStreak.count] ??
-                  `${visibleStreak.count}x STREAK`}
+                {gameState.mode === "tag"
+                  ? (TAG_STREAK_LABELS[visibleStreak.count] ??
+                    `${visibleStreak.count}x CHAIN`)
+                  : (STREAK_LABELS[visibleStreak.count] ??
+                    `${visibleStreak.count}x STREAK`)}
               </div>
               <div
                 style={{

--- a/src/components/gameModes/TagMode.ts
+++ b/src/components/gameModes/TagMode.ts
@@ -8,6 +8,15 @@ import type {
 
 const log = createLogger("TagMode");
 
+const TAG_STREAK_THRESHOLDS = [3, 5, 7, 10] as const;
+export const TAG_STREAK_LABELS: Record<number, string> = {
+  3: "ON A ROLL",
+  5: "TAGGING SPREE",
+  7: "UNTOUCHABLE",
+  10: "TAG GOD",
+};
+const TAG_STREAK_ANNOUNCE_MS = 3000;
+
 /**
  * Classic tag rules: one player is "IT" and tags others to pass on the
  * role. Scores reward fast tags; cooldowns prevent instant tag-back
@@ -29,6 +38,7 @@ export class TagMode implements GameModeHandler {
     const itPlayerId = this.pickRandomPlayer(players);
     gameState.itPlayerId = itPlayerId;
     gameState.killFeed = [];
+    gameState.streakAnnouncement = undefined;
 
     players.forEach((player, id) => {
       gameState.scores[id] = 0;
@@ -36,6 +46,7 @@ export class TagMode implements GameModeHandler {
       player.timeAsIt = 0;
       player.lastTagTime = undefined;
       player.lastTaggedById = undefined;
+      player.currentKillStreak = 0;
     });
   }
 
@@ -45,6 +56,14 @@ export class TagMode implements GameModeHandler {
     gameState: GameState,
   ): void {
     gameState.timeRemaining -= deltaTime;
+
+    const now = Date.now();
+    if (
+      gameState.streakAnnouncement !== undefined &&
+      now >= gameState.streakAnnouncement.timestamp + TAG_STREAK_ANNOUNCE_MS
+    ) {
+      gameState.streakAnnouncement = undefined;
+    }
   }
 
   onAction(
@@ -126,6 +145,20 @@ export class TagMode implements GameModeHandler {
     gameState.itPlayerId = taggedId;
     gameState.roundStartTime = now;
 
+    // Cumulative tag tally: each escape from IT earns a point toward callouts.
+    // Never reset mid-round (being re-tagged doesn't erase your tally) so that
+    // milestones are reachable in small games where IT always cycles back to you.
+    tagger.currentKillStreak = (tagger.currentKillStreak ?? 0) + 1;
+
+    const tally = tagger.currentKillStreak;
+    if ((TAG_STREAK_THRESHOLDS as readonly number[]).includes(tally)) {
+      gameState.streakAnnouncement = {
+        killerName: tagger.name,
+        count: tally,
+        timestamp: now,
+      };
+    }
+
     const tagEvent: KillEvent = {
       killerId: taggerId,
       killerName: tagger.name,
@@ -180,9 +213,11 @@ export class TagMode implements GameModeHandler {
       player.timeAsIt = 0;
       player.lastTagTime = undefined;
       player.lastTaggedById = undefined;
+      player.currentKillStreak = 0;
     });
 
     gameState.killFeed = undefined;
+    gameState.streakAnnouncement = undefined;
     return results;
   }
 


### PR DESCRIPTION
## Summary

- Added cumulative tag tally streak system to tag mode (`TagMode.ts`) — milestones at 3, 5, 7, 10 tags trigger "ON A ROLL", "TAGGING SPREE", "UNTOUCHABLE", "TAG GOD" callouts
- Tag streak announcements display in cyan/blue (distinct from deathmatch's orange kill streaks) via `GameUI.tsx`
- `onTick` auto-clears the announcement after 3s; `onStart`/`onEnd` reset tallies
- Tally is cumulative per round (not reset when you get re-tagged), making milestones reachable in small games where IT always cycles back to the same players
- Test added: chains 3 complete IT cycles and asserts `streakAnnouncement` fires with correct killer name and count=3

## Test plan
- [x] 878 tests passing, 10 skipped — no regressions
- [x] Pre-push CI clean
- [ ] Manual: start tag game, tag 3 bots (will take 3 IT cycles), verify "ON A ROLL" banner appears in cyan text centered on screen
- [ ] Manual: verify banner disappears after ~3 seconds
- [ ] Manual: deathmatch/CTF streak banners still show in orange (no color regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)