### PR TITLE
Phase AA: 3-way tag game — bot-2 joins tag mode for chaotic 3-player chases

### DIFF
--- a/src/pages/Solo.tsx
+++ b/src/pages/Solo.tsx
@@ -664,6 +664,17 @@ const Solo: React.FC = () => {
       return;
     }
 
+    // Add bot-2 so tag games are 3-way (player + bot-1 + bot-2).
+    if (!gameManager.current.getPlayers().has("bot-2")) {
+      const bot2Tag: Player = {
+        id: "bot-2",
+        name: BOT2_CONFIG.label || "Bot2",
+        position: BOT2_CONFIG.initialPosition,
+        rotation: ZERO_ROTATION,
+        isIt: false,
+      };
+      gameManager.current.addPlayer(bot2Tag);
+    }
     gameManager.current.startTagGame();
     const newGameState = gameManager.current.getGameState();
     setGameState(newGameState);
@@ -684,11 +695,19 @@ const Solo: React.FC = () => {
     if (gameManager.current) {
       const wasMode = gameManager.current.getGameState().mode;
       gameManager.current.endGame();
-      // Bot-2 and bot-3 were added for combat modes; remove them so the lobby shows 1v1 again.
-      // (Debug mode manages its own bot-2 lifecycle separately.)
-      if (!botDebugMode && (wasMode === "deathmatch" || wasMode === "ctf")) {
-        gameManager.current.removePlayer("bot-2");
-        gameManager.current.removePlayer("bot-3");
+      // Bot-2 was added for combat and tag modes; bot-3 for combat only.
+      // Remove them so the lobby shows 1v1 again. Debug mode manages its own bot-2.
+      if (!botDebugMode) {
+        if (
+          wasMode === "deathmatch" ||
+          wasMode === "ctf" ||
+          wasMode === "tag"
+        ) {
+          gameManager.current.removePlayer("bot-2");
+        }
+        if (wasMode === "deathmatch" || wasMode === "ctf") {
+          gameManager.current.removePlayer("bot-3");
+        }
       }
       syncGameState();
       addNotification("Game ended", "info");

--- a/src/pages/Solo/components/Bots.tsx
+++ b/src/pages/Solo/components/Bots.tsx
@@ -110,7 +110,11 @@ const Bots: React.FC<
   // Combat mode: bot-2 and bot-3 are AI opponents; bot-3 is combat-only.
   const isCombatMode =
     gameState.mode === "deathmatch" || gameState.mode === "ctf";
-  const showBot2 = botDebugMode || (isCombatMode && gameState.isActive);
+  const isTagMode = gameState.mode === "tag";
+  const showBot2 =
+    botDebugMode ||
+    (isCombatMode && gameState.isActive) ||
+    (isTagMode && gameState.isActive);
   const showBot3 = isCombatMode && gameState.isActive;
 
   // Team of each bot's current target, so CTF combat doesn't fire on allies.
@@ -195,11 +199,34 @@ const Bots: React.FC<
   ]);
 
   const handleBot2TagTarget = useCallback(() => {
-    if (gameManager && bot2IsIt && bot1IsIt === false) {
-      gameManager.tagPlayer("bot-2", "bot-1");
-      setBot1GotTagged(Date.now());
+    if (!gameManager || !bot2IsIt || !gameState.isActive) return;
+    if (botDebugMode) {
+      // Debug: bot-2 tags bot-1
+      if (!bot1IsIt) {
+        gameManager.tagPlayer("bot-2", "bot-1");
+        setBot1GotTagged(Date.now());
+      }
+      return;
     }
-  }, [gameManager, bot2IsIt, bot1IsIt, setBot1GotTagged]);
+    // Tag mode: bot-2 tags the player when IT and the player isn't already IT
+    if (gameState.mode === "tag" && !playerIsItFromManager) {
+      const result = gameManager.tagPlayer("bot-2", currentPlayerId);
+      if (result && typeof window !== "undefined") {
+        const event = new window.Event("player-tagged-by-bot");
+        window.dispatchEvent(event);
+      }
+    }
+  }, [
+    gameManager,
+    bot2IsIt,
+    bot1IsIt,
+    gameState.isActive,
+    gameState.mode,
+    botDebugMode,
+    currentPlayerId,
+    playerIsItFromManager,
+    setBot1GotTagged,
+  ]);
 
   // Each bot gets its own WeaponManager so they can use different weapons.
   // Bot-1: Pulse Shotgun, Bot-2: Rocket Launcher, Bot-3: Frag Grenade.

--- a/src/pages/Solo/components/__tests__/Bots.test.tsx
+++ b/src/pages/Solo/components/__tests__/Bots.test.tsx
@@ -79,12 +79,13 @@ describe("Bots", () => {
     };
   }
 
-  it("renders one bot in normal mode and tags current player", () => {
+  it("renders two bots in tag mode and bot-1 tags current player", () => {
     const dispatchSpy = vi.spyOn(window, "dispatchEvent");
     const props = buildProps();
 
     render(<Bots {...props} />);
-    expect(screen.getAllByRole("button")).toHaveLength(1);
+    // tag mode now shows bot-1 + bot-2
+    expect(screen.getAllByRole("button")).toHaveLength(2);
 
     fireEvent.click(screen.getByTestId("bot-1"));
 
@@ -149,6 +150,32 @@ describe("Bots", () => {
     expect(setBot2GotTagged).toHaveBeenCalledWith(1234);
 
     nowSpy.mockRestore();
+  });
+
+  it("bot-2 tags player in non-debug tag mode when IT", () => {
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+    const players = new Map<string, { isIt: boolean }>([
+      ["bot-1", { isIt: false }],
+      ["bot-2", { isIt: true }],
+      ["player-1", { isIt: false }],
+    ]);
+    const tagPlayer = vi.fn(() => true);
+    const props = buildProps({
+      gameManager: {
+        getPlayers: () => players,
+        tagPlayer,
+      } as unknown as React.ComponentProps<typeof Bots>["gameManager"],
+    });
+
+    render(<Bots {...props} />);
+    // tag mode shows bot-1 and bot-2
+    expect(screen.getAllByRole("button")).toHaveLength(2);
+
+    // Click bot-2's onTagTarget
+    fireEvent.click(screen.getByTestId("bot-2"));
+
+    expect(tagPlayer).toHaveBeenCalledWith("bot-2", "player-1");
+    expect(dispatchSpy).toHaveBeenCalled();
   });
 
   it("blocks an immediate IT ping-pong when bot-2 tries to tag bot-1 right back", () => {


### PR DESCRIPTION
## Summary

- Tag mode now spawns 3 participants: player, bot-1, and bot-2 (previously only player + bot-1)
- `showBot2` in `Bots.tsx` extended to include `isTagMode && gameState.isActive`
- `handleBot2TagTarget` updated to tag the human player in non-debug tag mode when bot-2 is IT (dispatches `player-tagged-by-bot` event for freeze animation, same as bot-1)
- `Solo.tsx`: registers bot-2 before `startTagGame()`, removes it in `handleEndGame` when mode was tag
- Test updated: "renders one bot in normal mode" → now expects 2 bots in tag mode
- New test: bot-2 tags player-1 when IT in non-debug tag mode

## Test plan
- [x] 879 tests passing, 10 skipped — +1 new test, no regressions
- [ ] Manual: start tag game, verify both bot-1 and bot-2 appear and chase/flee appropriately
- [ ] Manual: when bot-2 is IT, verify it can laser-tag the player from range
- [ ] Manual: verify bot-2 is removed when ending the tag game (lobby goes back to 1 bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)