### PR TITLE
Phase AB: deathmatch bot-vs-bot combat — triangle of fire (bot-2→bot-1, bot-3→bot-2)

### DIFF
--- a/src/pages/Solo/components/Bots.tsx
+++ b/src/pages/Solo/components/Bots.tsx
@@ -117,16 +117,34 @@ const Bots: React.FC<
     (isTagMode && gameState.isActive);
   const showBot3 = isCombatMode && gameState.isActive;
 
+  const isDeathmatch = gameState.mode === "deathmatch";
+
+  // In deathmatch: bots target each other (triangle of fire). Bot-2 targets
+  // bot-1; bot-3 targets bot-2. Fall back to player when primary is downed.
+  const bot2DmTargetRef =
+    isDeathmatch && !bot1IsDowned ? bot1PositionRef : playerPositionRef;
+  const bot3DmTargetRef =
+    isDeathmatch && !bot2IsDowned ? bot2PositionRef : playerPositionRef;
+  // Fire targets mirror position refs.
+  const bot2DmFireTarget =
+    isDeathmatch && !bot1IsDowned ? "bot-1" : currentPlayerId;
+  const bot3DmFireTarget =
+    isDeathmatch && !bot2IsDowned ? "bot-2" : currentPlayerId;
+
   // Team of each bot's current target, so CTF combat doesn't fire on allies.
   const bot1TargetTeam = botDebugMode
     ? bot2Team
     : gameManager?.getPlayers().get(currentPlayerId)?.team;
-  // In debug mode bot-2 targets bot-1's team; in combat mode it targets the player.
+  // In debug mode bot-2 targets bot-1's team; in deathmatch it targets bot-1's team.
   const bot2TargetTeam = botDebugMode
     ? bot1Team
+    : isDeathmatch
+      ? bot1Team
+      : gameManager?.getPlayers().get(currentPlayerId)?.team;
+  // Bot-3 targets bot-2's team in deathmatch; player otherwise.
+  const bot3TargetTeam = isDeathmatch
+    ? bot2Team
     : gameManager?.getPlayers().get(currentPlayerId)?.team;
-  // Bot-3 is combat-only and always targets the player.
-  const bot3TargetTeam = gameManager?.getPlayers().get(currentPlayerId)?.team;
   // Derive player isIt from gameManager to avoid stale React-state race windows
   const playerIsItFromManager =
     gameManager?.getPlayers().get(currentPlayerId)?.isIt ?? playerIsIt;
@@ -304,13 +322,14 @@ const Bots: React.FC<
   }, [fireBotWeapon, botDebugMode, currentPlayerId]);
 
   const handleBot2FireAtTarget = useCallback(() => {
-    // In debug mode bot-2 fights bot-1; in combat mode it targets the player.
-    fireBotWeapon("bot-2", botDebugMode ? "bot-1" : currentPlayerId);
-  }, [fireBotWeapon, botDebugMode, currentPlayerId]);
+    // Debug: bot-2 fights bot-1. Deathmatch: also targets bot-1 (fallback player).
+    fireBotWeapon("bot-2", botDebugMode ? "bot-1" : bot2DmFireTarget);
+  }, [fireBotWeapon, botDebugMode, bot2DmFireTarget]);
 
   const handleBot3FireAtTarget = useCallback(() => {
-    fireBotWeapon("bot-3", currentPlayerId);
-  }, [fireBotWeapon, currentPlayerId]);
+    // Deathmatch: bot-3 targets bot-2 (fallback player). Otherwise: player.
+    fireBotWeapon("bot-3", bot3DmFireTarget);
+  }, [fireBotWeapon, bot3DmFireTarget]);
 
   return (
     <>
@@ -354,7 +373,7 @@ const Bots: React.FC<
 
       {showBot2 && (
         <BotCharacter
-          targetPositionRef={botDebugMode ? bot1PositionRef : playerPositionRef}
+          targetPositionRef={botDebugMode ? bot1PositionRef : bot2DmTargetRef}
           isIt={bot2IsIt}
           targetIsIt={botDebugMode ? bot1IsIt : playerIsItFromManager}
           isPaused={isPaused}
@@ -376,7 +395,7 @@ const Bots: React.FC<
 
       {showBot3 && (
         <BotCharacter
-          targetPositionRef={playerPositionRef}
+          targetPositionRef={bot3DmTargetRef}
           isIt={false}
           targetIsIt={playerIsItFromManager}
           isPaused={isPaused}


### PR DESCRIPTION
## Summary

- In deathmatch, bots now target each other creating a 3-way "triangle of fire":
  - Bot-1 targets the player (unchanged)
  - Bot-2 targets Bot-1 (new); falls back to player if Bot-1 is downed
  - Bot-3 targets Bot-2 (new); falls back to player if Bot-2 is downed
- `fireBotWeapon` targets mirror the position refs (bot-2 fires at "bot-1", bot-3 fires at "bot-2")
- `targetTeam` updated so bot-2 and bot-3 use their actual combat target's team for friendly-fire checks
- CTF and tag mode behavior unchanged (deathmatch-specific via `isDeathmatch` flag)

## Test plan
- [x] 879 tests passing, 10 skipped — no regressions
- [ ] Manual: start deathmatch, observe bot-2 moving toward bot-1 and exchanging fire
- [ ] Manual: kill bot-1 (downed), verify bot-2 switches to targeting player
- [ ] Manual: CTF behavior unchanged — bots still pursue flags with team-based combat

🤖 Generated with [Claude Code](https://claude.com/claude-code)