### PR TITLE
Phase AC: player respawn teleport to spawn + medal emojis on results screen

### DIFF
--- a/src/components/GameUI.tsx
+++ b/src/components/GameUI.tsx
@@ -733,7 +733,8 @@ const GameUI: React.FC<GameUIProps> = ({
               }}
             >
               <span>
-                {i + 1}. {r.name}
+                {i === 0 ? "🥇" : i === 1 ? "🥈" : i === 2 ? "🥉" : "🏅"}{" "}
+                {r.name}
               </span>
               <span>
                 {r.score} {scoreLabel}

--- a/src/components/characters/PlayerCharacter.tsx
+++ b/src/components/characters/PlayerCharacter.tsx
@@ -253,6 +253,20 @@ export const PlayerCharacter = React.forwardRef<
       window.removeEventListener("health-pickup", handleHealthPickup);
   }, [gameManager, currentPlayerId]);
 
+  // Teleport player back to spawn when respawn timer clears (deathmatch/CTF).
+  // Mirrors the equivalent logic in useBotAI for bots.
+  const mePlayer = gameManager?.getPlayers().get(currentPlayerId);
+  const respawnAt = mePlayer?.respawnAt;
+  const prevRespawnAtRef = React.useRef<number | undefined>(undefined);
+  React.useEffect(() => {
+    const wasDown = prevRespawnAtRef.current !== undefined;
+    const isUp = respawnAt === undefined;
+    if (wasDown && isUp && meshRef.current) {
+      meshRef.current.position.set(0, 0.5, 0);
+    }
+    prevRespawnAtRef.current = respawnAt;
+  }, [respawnAt, meshRef]);
+
   // gated debug logger - only logs in dev
   const debug = (...args: unknown[]) => {
     // Vite exposes import.meta.env.DEV; fall back to false if undefined


### PR DESCRIPTION
## Summary

- When a downed player's `respawnAt` clears (timer elapses), their mesh teleports back to spawn [0, 0.5, 0] — mirrors the equivalent bot respawn logic in `useBotAI`
- Results screen now shows 🥇🥈🥉🏅 medals for top-4 finishers

## Test plan

- [x] 879 tests passing, 0 new failures
- [x] Lint clean (eslint --max-warnings=0)
- Manual: die in deathmatch → respawn countdown → player snaps to spawn on comeback

🤖 Generated with [Claude Code](https://claude.com/claude-code)