### PR TITLE
Phase AF: bot health bars — green/orange/red billboarded HP strips in combat modes

### DIFF
--- a/src/components/characters/BotCharacter.tsx
+++ b/src/components/characters/BotCharacter.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { useRef, useEffect } from "react";
 import * as THREE from "three";
+import { Billboard } from "@react-three/drei";
 import SpacemanModel from "../SpacemanModel";
 import CollisionSystem from "../CollisionSystem";
 import { GameState } from "../GameManager";
@@ -29,6 +30,10 @@ export interface BotCharacterProps {
   isCarryingFlag?: boolean;
   /** The target's team assignment (CTF) - used to avoid friendly fire. */
   targetTeam?: "a" | "b";
+  /** Current health (deathmatch/CTF). Drives the health bar. */
+  health?: number;
+  /** Max health — used to compute the health bar fill fraction. */
+  maxHealth?: number;
   gameState: GameState;
   collisionSystem: React.RefObject<CollisionSystem | null>;
   gotTaggedTimestamp?: number;
@@ -61,6 +66,8 @@ export const BotCharacter: React.FC<BotCharacterProps> = ({
   config,
   color,
   labelColor,
+  health,
+  maxHealth,
 }) => {
   const meshRef = useRef<THREE.Group>(null);
 
@@ -99,6 +106,26 @@ export const BotCharacter: React.FC<BotCharacterProps> = ({
     0.0,
     config.initialPosition[2],
   ];
+
+  // Health bar geometry — only in combat modes where health matters
+  const showHealthBar =
+    health !== undefined &&
+    maxHealth !== undefined &&
+    maxHealth > 0 &&
+    gameState.mode !== "tag";
+  const healthFraction = showHealthBar
+    ? Math.max(0, health as number) / (maxHealth as number)
+    : 0;
+  const BAR_W = 0.65;
+  const fillW = BAR_W * healthFraction;
+  const fillX = -(BAR_W - fillW) / 2;
+  const fillColor =
+    healthFraction > 0.5
+      ? "#44ff44"
+      : healthFraction > 0.25
+        ? "#ffaa00"
+        : "#ff3333";
+
   return (
     <group
       ref={meshRef}
@@ -117,6 +144,26 @@ export const BotCharacter: React.FC<BotCharacterProps> = ({
         <sphereGeometry args={[0.12, 8, 8]} />
         <meshBasicMaterial color={isIt ? "#ff4444" : labelColor || color} />
       </mesh>
+      {/* Health bar — always faces camera via Billboard, hidden in tag mode */}
+      {showHealthBar && (
+         
+        <Billboard position={[0, 1.9, 0]}>
+          {/* Background track */}
+          { }
+          <mesh>
+            <boxGeometry args={[BAR_W, 0.08, 0.01]} />
+            <meshBasicMaterial color="#111111" />
+          </mesh>
+          {/* Fill — left-anchored, shrinks right as health drops */}
+          {fillW > 0 && (
+             
+            <mesh position={[fillX, 0, 0.006]}>
+              <boxGeometry args={[fillW, 0.08, 0.01]} />
+              <meshBasicMaterial color={fillColor} />
+            </mesh>
+          )}
+        </Billboard>
+      )}
       {/* Debug hitbox visualization */}
       {showHitboxes && (
         <mesh position={[0, 0, 0]}>

--- a/src/pages/Solo/components/Bots.tsx
+++ b/src/pages/Solo/components/Bots.tsx
@@ -97,6 +97,13 @@ const Bots: React.FC<
     gameManager?.getPlayers().get("bot-2")?.respawnAt !== undefined;
   const bot3IsDowned =
     gameManager?.getPlayers().get("bot-3")?.respawnAt !== undefined;
+  // Health for health-bar display in combat modes
+  const bot1Health = gameManager?.getPlayers().get("bot-1")?.health;
+  const bot1MaxHealth = gameManager?.getPlayers().get("bot-1")?.maxHealth;
+  const bot2Health = gameManager?.getPlayers().get("bot-2")?.health;
+  const bot2MaxHealth = gameManager?.getPlayers().get("bot-2")?.maxHealth;
+  const bot3Health = gameManager?.getPlayers().get("bot-3")?.health;
+  const bot3MaxHealth = gameManager?.getPlayers().get("bot-3")?.maxHealth;
   // Team assignment and carried-flag status for CTF
   const bot1Team = gameManager?.getPlayers().get("bot-1")?.team;
   const bot2Team = gameManager?.getPlayers().get("bot-2")?.team;
@@ -369,6 +376,8 @@ const Bots: React.FC<
         gotTaggedTimestamp={bot1GotTagged}
         config={effectiveBot1Config}
         color="#ff8888"
+        health={bot1Health}
+        maxHealth={bot1MaxHealth}
       />
 
       {showBot2 && (
@@ -390,6 +399,8 @@ const Bots: React.FC<
           config={effectiveBot2Config}
           color="#88ff88"
           labelColor="#00ff00"
+          health={bot2Health}
+          maxHealth={bot2MaxHealth}
         />
       )}
 
@@ -412,6 +423,8 @@ const Bots: React.FC<
           config={effectiveBot3Config}
           color="#ffaa00"
           labelColor="#ff8800"
+          health={bot3Health}
+          maxHealth={bot3MaxHealth}
         />
       )}
     </>


### PR DESCRIPTION
## Summary

- Bot health bars appear above each bot's head during deathmatch and CTF (hidden in tag mode where health isn't tracked)
- `Billboard` from `@react-three/drei` ensures bars always face the camera regardless of bot orientation
- Color transitions: green (>50%) → orange (25-50%) → red (<25%)
- Fill shrinks left-to-right as health drops; bar disappears when bot is at 0 HP and respawning
- `BotCharacter` gains optional `health`/`maxHealth` props; `Bots.tsx` reads them from `gameManager.getPlayers()`

## Test plan

- [x] 879 tests passing, 0 new failures
- [x] Lint clean
- Manual: start deathmatch → each bot shows a green bar; shoot a bot → bar shrinks and yellows/reddens

🤖 Generated with [Claude Code](https://claude.com/claude-code)