### PR TITLE
fix: resolve TypeScript errors introduced in Phase AF

### DIFF
--- a/src/__tests__/bots.tagging.test.tsx
+++ b/src/__tests__/bots.tagging.test.tsx
@@ -71,6 +71,9 @@ describe("Bots tagging behavior", () => {
         bot2GotTagged={0}
         BOT1_CONFIG={{ label: "Bot1" }}
         BOT2_CONFIG={{ label: "Bot2" }}
+        BOT3_CONFIG={{ label: "Bot3" }}
+        handleBot3PositionUpdate={() => {}}
+        bot3GotTagged={0}
         gameManager={manager}
         gameState={manager.getGameState()}
         setBot1GotTagged={() => {}}

--- a/src/components/characters/PlayerCharacter.tsx
+++ b/src/components/characters/PlayerCharacter.tsx
@@ -553,7 +553,7 @@ export const PlayerCharacter = React.forwardRef<
         const remainingAmmo = weaponManagerRef.current.getAmmo(wid);
         gameManager?.updatePlayer(myId, { currentAmmo: remainingAmmo });
       }
-      if (fireResult.hit && typeof window !== "undefined") {
+      if (fireResult && fireResult.hit && typeof window !== "undefined") {
         // Notify HUD to flash hit marker.
         window.dispatchEvent(new window.Event("player-hit-landed"));
         // Trigger explosion VFX for splash weapons (rocket, grenade).

--- a/src/pages/Solo/components/Bots.tsx
+++ b/src/pages/Solo/components/Bots.tsx
@@ -301,7 +301,7 @@ const Bots: React.FC<
         if (equipped) {
           const ammo = weaponRef.current.getAmmo(equipped.id);
           if (ammo !== null && ammo <= 0) {
-            weaponRef.current.refillAmmo(equipped.id);
+            weaponRef.current.refill(equipped.id);
           }
         }
         return;


### PR DESCRIPTION
## Summary
- `PlayerCharacter.tsx`: guard `fireResult` against null before accessing `.hit` (TS18047 — `fireResult` is possibly null when no shot was taken this frame)
- `Bots.tsx`: rename `refillAmmo` → `refill` to match the actual `WeaponManager` API (TS2339)
- `bots.tagging.test.tsx`: add the three bot-3 props (`BOT3_CONFIG`, `handleBot3PositionUpdate`, `bot3GotTagged`) that became required when bot-3 was added in Phase AB

## Test plan
- [x] 879 tests pass locally (Docker)
- [x] Lint + ESLint clean
- [x] Addresses the CI failure blocking dependabot PR #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)