### PR TITLE
Phase AG: player health bar + arena cover crates (#287)

### DIFF
--- a/src/__tests__/bots.tagging.test.tsx
+++ b/src/__tests__/bots.tagging.test.tsx
@@ -71,6 +71,9 @@ describe("Bots tagging behavior", () => {
         bot2GotTagged={0}
         BOT1_CONFIG={{ label: "Bot1" }}
         BOT2_CONFIG={{ label: "Bot2" }}
+        BOT3_CONFIG={{ label: "Bot3" }}
+        handleBot3PositionUpdate={() => {}}
+        bot3GotTagged={0}
         gameManager={manager}
         gameState={manager.getGameState()}
         setBot1GotTagged={() => {}}

--- a/src/components/CollisionSystem.ts
+++ b/src/components/CollisionSystem.ts
@@ -127,6 +127,36 @@ export class CollisionSystem {
         new THREE.Vector3(-2.2, 1.2, 15.8),
       ),
     );
+
+    // Mid-field cover crates — symmetric cross matching Environment.tsx geometry
+    // North crate [0, 8]: 3w × 1.5h × 2d
+    this.boundaries.push(
+      new THREE.Box3(
+        new THREE.Vector3(-1.5, 0, 7),
+        new THREE.Vector3(1.5, 1.5, 9),
+      ),
+    );
+    // South crate [0, -8]: 3w × 1.5h × 2d
+    this.boundaries.push(
+      new THREE.Box3(
+        new THREE.Vector3(-1.5, 0, -9),
+        new THREE.Vector3(1.5, 1.5, -7),
+      ),
+    );
+    // East crate [8, 0]: 2w × 1.5h × 3d
+    this.boundaries.push(
+      new THREE.Box3(
+        new THREE.Vector3(7, 0, -1.5),
+        new THREE.Vector3(9, 1.5, 1.5),
+      ),
+    );
+    // West crate [-8, 0]: 2w × 1.5h × 3d
+    this.boundaries.push(
+      new THREE.Box3(
+        new THREE.Vector3(-9, 0, -1.5),
+        new THREE.Vector3(-7, 1.5, 1.5),
+      ),
+    );
   }
 
   checkCollision(

--- a/src/components/GameUI.tsx
+++ b/src/components/GameUI.tsx
@@ -597,19 +597,63 @@ const GameUI: React.FC<GameUIProps> = ({
                 padding: "4px 12px",
               }}
             >
-              {/* Health — combat modes only (no health in tag mode) */}
-              {gameState.mode !== "tag" && (
-                <>
-                  <span style={{ color: "#ff6666" }}>
-                    ❤️ {currentPlayer.health ?? currentPlayer.maxHealth ?? 100}
-                    <span style={{ color: "#666", marginLeft: "2px" }}>
-                      /{currentPlayer.maxHealth ?? 100}
-                    </span>
-                  </span>
-                  {/* Divider */}
-                  <span style={{ color: "#444" }}>|</span>
-                </>
-              )}
+              {/* Health bar — combat modes only (no health in tag mode) */}
+              {gameState.mode !== "tag" &&
+                (() => {
+                  const hp =
+                    currentPlayer.health ?? currentPlayer.maxHealth ?? 100;
+                  const maxHp = currentPlayer.maxHealth ?? 100;
+                  const frac = Math.max(0, Math.min(1, hp / maxHp));
+                  const barColor =
+                    frac > 0.5
+                      ? "#44ff44"
+                      : frac > 0.25
+                        ? "#ffaa00"
+                        : "#ff3333";
+                  return (
+                    <>
+                      <div
+                        style={{
+                          display: "flex",
+                          flexDirection: "column",
+                          alignItems: "center",
+                          gap: "2px",
+                        }}
+                      >
+                        <div
+                          style={{
+                            fontSize: "9px",
+                            color: barColor,
+                            fontWeight: "bold",
+                            lineHeight: 1,
+                          }}
+                        >
+                          HP {hp}/{maxHp}
+                        </div>
+                        <div
+                          style={{
+                            width: "80px",
+                            height: "7px",
+                            background: "#1a1a1a",
+                            borderRadius: "2px",
+                            overflow: "hidden",
+                            border: "1px solid #333",
+                          }}
+                        >
+                          <div
+                            style={{
+                              width: `${frac * 100}%`,
+                              height: "100%",
+                              background: barColor,
+                              transition: "width 0.15s, background 0.3s",
+                            }}
+                          />
+                        </div>
+                      </div>
+                      <span style={{ color: "#444" }}>|</span>
+                    </>
+                  );
+                })()}
               {/* Weapon name + ammo pips */}
               {currentPlayer.equippedWeaponId &&
                 (() => {

--- a/src/components/characters/PlayerCharacter.tsx
+++ b/src/components/characters/PlayerCharacter.tsx
@@ -553,7 +553,7 @@ export const PlayerCharacter = React.forwardRef<
         const remainingAmmo = weaponManagerRef.current.getAmmo(wid);
         gameManager?.updatePlayer(myId, { currentAmmo: remainingAmmo });
       }
-      if (fireResult.hit && typeof window !== "undefined") {
+      if (fireResult && fireResult.hit && typeof window !== "undefined") {
         // Notify HUD to flash hit marker.
         window.dispatchEvent(new window.Event("player-hit-landed"));
         // Trigger explosion VFX for splash weapons (rocket, grenade).

--- a/src/pages/Solo/components/Bots.tsx
+++ b/src/pages/Solo/components/Bots.tsx
@@ -301,7 +301,7 @@ const Bots: React.FC<
         if (equipped) {
           const ammo = weaponRef.current.getAmmo(equipped.id);
           if (ammo !== null && ammo <= 0) {
-            weaponRef.current.refillAmmo(equipped.id);
+            weaponRef.current.refill(equipped.id);
           }
         }
         return;

--- a/src/pages/Solo/components/Environment.tsx
+++ b/src/pages/Solo/components/Environment.tsx
@@ -36,6 +36,50 @@ const Environment: React.FC<Props> = ({ qualitySettings, rockPositions }) => {
           <meshStandardMaterial color="#666666" />
         </mesh>
       ))}
+
+      {/* Corner bunkers — match the 4 corner collision boxes in CollisionSystem */}
+      {(
+        [
+          [17.5, 17.5],
+          [-17.5, -17.5],
+          [17.5, -17.5],
+          [-17.5, 17.5],
+        ] as [number, number][]
+      ).map(([cx, cz], i) => (
+        <mesh
+          key={`bunker-${i}`}
+          position={[cx, 1.5, cz]}
+          castShadow
+          receiveShadow
+        >
+          <boxGeometry args={[5, 3, 5]} />
+          <meshStandardMaterial color="#4a4035" roughness={0.9} />
+        </mesh>
+      ))}
+
+      {/* Mid-field cover crates — symmetric cross, match CollisionSystem entries */}
+      {(
+        [
+          [0, 8, 3, 1.5, 2], // north: 3w × 1.5h × 2d
+          [0, -8, 3, 1.5, 2], // south
+          [8, 0, 2, 1.5, 3], // east:  2w × 1.5h × 3d
+          [-8, 0, 2, 1.5, 3], // west
+        ] as [number, number, number, number, number][]
+      ).map(([cx, cz, w, h, d], i) => (
+        <mesh
+          key={`cover-${i}`}
+          position={[cx, h / 2, cz]}
+          castShadow
+          receiveShadow
+        >
+          <boxGeometry args={[w, h, d]} />
+          <meshStandardMaterial
+            color="#556677"
+            roughness={0.8}
+            metalness={0.2}
+          />
+        </mesh>
+      ))}
     </>
   );
 };


### PR DESCRIPTION
## Summary
- **Player health bar**: bottom HUD now shows a visual green→orange→red fill bar (matching bot health bar aesthetic) instead of plain `❤️ N / 100` text
- **Corner bunkers**: 4 dark-brown bunker structures rendered at the existing collision-box positions in the map corners (were invisible before)
- **Mid-field cover crates**: 4 symmetric blue-gray metal crates in a cross pattern at [0,±8] and [±8,0], each 1.5 units tall — creates tactical cover at midfield
- **CollisionSystem**: added 4 new boundary boxes matching the mid-field crate geometry

## Test plan
- [x] 879 tests pass (Docker)
- [x] Lint clean, TS clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)