### PR TITLE
Phase AH: floating damage numbers on hit (#288)

### DIFF
--- a/src/components/characters/PlayerCharacter.tsx
+++ b/src/components/characters/PlayerCharacter.tsx
@@ -556,11 +556,23 @@ export const PlayerCharacter = React.forwardRef<
       if (fireResult && fireResult.hit && typeof window !== "undefined") {
         // Notify HUD to flash hit marker.
         window.dispatchEvent(new window.Event("player-hit-landed"));
+        // Compute hit position for VFX/damage numbers.
+        const hitPos = fireOrigin
+          .clone()
+          .add(fireDirection.clone().multiplyScalar(fireResult.hit.distance));
+        // Floating damage number at hit point.
+        window.dispatchEvent(
+          new window.CustomEvent("damage-number", {
+            detail: {
+              x: hitPos.x,
+              y: hitPos.y + 1.0,
+              z: hitPos.z,
+              damage: fireResult.weapon.damage,
+            },
+          }),
+        );
         // Trigger explosion VFX for splash weapons (rocket, grenade).
         if (fireResult.weapon.splashRadius) {
-          const hitPos = fireOrigin
-            .clone()
-            .add(fireDirection.clone().multiplyScalar(fireResult.hit.distance));
           window.dispatchEvent(
             new window.CustomEvent("weapon-explosion", {
               detail: {

--- a/src/components/world/DamageNumbers.tsx
+++ b/src/components/world/DamageNumbers.tsx
@@ -1,0 +1,107 @@
+import * as React from "react";
+import * as THREE from "three";
+import { Billboard, Text } from "@react-three/drei";
+import { useFrame } from "@react-three/fiber";
+
+const DURATION_MS = 1100;
+const MAX_SLOTS = 8;
+
+type Slot = {
+  active: boolean;
+  startedAt: number;
+  x: number;
+  y: number;
+  z: number;
+  damage: number;
+};
+
+const makeSlot = (): Slot => ({
+  active: false,
+  startedAt: 0,
+  x: 0,
+  y: 0,
+  z: 0,
+  damage: 0,
+});
+
+const DamageNumbers: React.FC = () => {
+  const [pool, setPool] = React.useState<Slot[]>(() =>
+    Array.from({ length: MAX_SLOTS }, makeSlot),
+  );
+  const poolRef = React.useRef<Slot[]>(pool);
+  const groupRefs = React.useRef<(THREE.Group | null)[]>(
+    Array(MAX_SLOTS).fill(null),
+  );
+
+  React.useEffect(() => {
+    const handle = (e: unknown) => {
+      const { x, y, z, damage } = (
+        e as { detail: { x: number; y: number; z: number; damage: number } }
+      ).detail;
+      const now = Date.now();
+      const i = poolRef.current.findIndex(
+        (s) => !s.active || now - s.startedAt > DURATION_MS,
+      );
+      if (i === -1) return;
+      const next = [...poolRef.current];
+      next[i] = { active: true, startedAt: now, x, y, z, damage };
+      poolRef.current = next;
+      setPool(next);
+    };
+    window.addEventListener("damage-number", handle);
+    return () => window.removeEventListener("damage-number", handle);
+  }, []);
+
+  useFrame(() => {
+    const now = Date.now();
+    for (let i = 0; i < MAX_SLOTS; i++) {
+      const slot = poolRef.current[i];
+      const g = groupRefs.current[i];
+      if (!g) continue;
+      if (!slot.active) {
+        g.visible = false;
+        continue;
+      }
+      const elapsed = now - slot.startedAt;
+      if (elapsed >= DURATION_MS) {
+        g.visible = false;
+        continue;
+      }
+      g.visible = true;
+      const t = elapsed / DURATION_MS;
+      g.position.set(slot.x, slot.y + 0.5 + t * 2.2, slot.z);
+    }
+  });
+
+  return (
+    <>
+      {pool.map((slot, i) => (
+        <group
+          key={i}
+          ref={(el: THREE.Group | null) => {
+            groupRefs.current[i] = el;
+          }}
+          // eslint-disable-next-line react/no-unknown-property
+          visible={false}
+        >
+          {slot.active && (
+            <Billboard>
+              <Text
+                fontSize={0.45}
+                color="#ff4444"
+                anchorX="center"
+                anchorY="middle"
+                outlineWidth={0.04}
+                outlineColor="#000000"
+              >
+                {`-${slot.damage}`}
+              </Text>
+            </Billboard>
+          )}
+        </group>
+      ))}
+    </>
+  );
+};
+
+export default DamageNumbers;

--- a/src/pages/Solo/components/Bots.tsx
+++ b/src/pages/Solo/components/Bots.tsx
@@ -319,6 +319,21 @@ const Bots: React.FC<
         } catch {
           // sound is best-effort only
         }
+        if (typeof window !== "undefined") {
+          const targetPos = gameManager.getPlayers().get(targetId)?.position;
+          if (targetPos) {
+            window.dispatchEvent(
+              new window.CustomEvent("damage-number", {
+                detail: {
+                  x: targetPos[0],
+                  y: targetPos[1] + 1.5,
+                  z: targetPos[2],
+                  damage: weapon.damage,
+                },
+              }),
+            );
+          }
+        }
       }
     },
     [gameManager, gameState.mode, gameState.isActive],

--- a/src/pages/Solo/components/SoloScene.tsx
+++ b/src/pages/Solo/components/SoloScene.tsx
@@ -6,6 +6,7 @@ import Bots from "./Bots";
 import WeaponPickups from "../../../components/world/WeaponPickups";
 import HealthPickups from "../../../components/world/HealthPickups";
 import ExplosionVFX from "../../../components/world/ExplosionVFX";
+import DamageNumbers from "../../../components/world/DamageNumbers";
 import type { SoloSceneProps } from "./SoloScene.types";
 
 type Props = SoloSceneProps;
@@ -118,6 +119,7 @@ export const SoloScene: React.FC<Props> = ({
         gameState={gameState}
       />
       <ExplosionVFX />
+      <DamageNumbers />
     </Canvas>
   );
 };


### PR DESCRIPTION
## Summary
- **DamageNumbers.tsx**: pooled 8-slot component using `Billboard + Text` from drei, renders red `-N` text floating up 2.2 world units from hit position over 1.1s. Position animated per-frame via `useFrame` (zero React re-renders during flight). Text content and slot activation driven by React state on new events.
- **PlayerCharacter**: fires `"damage-number"` event at the ray-cast hit position when player's shot connects (reuses `hitPos` computed for explosion VFX)
- **Bots**: fires `"damage-number"` event at the target's world position when a bot hit lands
- **SoloScene**: mounts `<DamageNumbers />` inside Canvas

## Test plan
- [x] 879 tests pass (Docker)
- [x] Lint clean, TS clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)