### PR TITLE
Phase AJ: anti-camping spawn selection on respawn (#290)

### DIFF
--- a/src/components/characters/PlayerCharacter.tsx
+++ b/src/components/characters/PlayerCharacter.tsx
@@ -24,6 +24,7 @@ import { getSoundManager } from "../SoundManager";
 import { WeaponManager } from "../combat/WeaponManager";
 import { processFiring } from "../../lib/hooks/usePlayerWeapon";
 import { createTagLogger } from "../../lib/utils/logger";
+import { pickSafeSpawn } from "../../lib/constants/spawnPoints";
 import {
   usePlayerPhysics,
   PHYSICS_CONSTANTS,
@@ -254,7 +255,7 @@ export const PlayerCharacter = React.forwardRef<
   }, [gameManager, currentPlayerId]);
 
   // Teleport player back to spawn when respawn timer clears (deathmatch/CTF).
-  // Mirrors the equivalent logic in useBotAI for bots.
+  // Picks the spawn point farthest from all alive enemies (anti-camping).
   const mePlayer = gameManager?.getPlayers().get(currentPlayerId);
   const respawnAt = mePlayer?.respawnAt;
   const prevRespawnAtRef = React.useRef<number | undefined>(undefined);
@@ -262,10 +263,17 @@ export const PlayerCharacter = React.forwardRef<
     const wasDown = prevRespawnAtRef.current !== undefined;
     const isUp = respawnAt === undefined;
     if (wasDown && isUp && meshRef.current) {
-      meshRef.current.position.set(0, 0.5, 0);
+      const enemyPositions: [number, number, number][] = [];
+      gameManager?.getPlayers().forEach((p, id) => {
+        if (id !== currentPlayerId && p.respawnAt === undefined) {
+          enemyPositions.push(p.position as [number, number, number]);
+        }
+      });
+      const [sx, sy, sz] = pickSafeSpawn(enemyPositions);
+      meshRef.current.position.set(sx, sy, sz);
     }
     prevRespawnAtRef.current = respawnAt;
-  }, [respawnAt, meshRef]);
+  }, [respawnAt, meshRef, gameManager, currentPlayerId]);
 
   // gated debug logger - only logs in dev
   const debug = (...args: unknown[]) => {

--- a/src/components/characters/useBotAI.ts
+++ b/src/components/characters/useBotAI.ts
@@ -5,6 +5,7 @@ import * as THREE from "three";
 import CollisionSystem from "../CollisionSystem";
 import { GameState } from "../GameManager";
 import { createTagLogger } from "../../lib/utils/logger";
+import { SPAWN_POINTS } from "../../lib/constants/spawnPoints";
 
 const tagDebug = createTagLogger("BotAI");
 
@@ -109,16 +110,17 @@ export function useBotAI({
   const sprintEndTime = useRef(0);
   const nextSprintTime = useRef(0);
 
-  // Teleport bot back to spawn when it respawns after being downed.
+  // Teleport bot back to a random spawn point when it respawns after being downed.
   const prevIsDownedRef = useRef(isDowned);
   useEffect(() => {
     if (prevIsDownedRef.current && !isDowned && meshRef.current) {
-      meshRef.current.position.set(...config.initialPosition);
-      lastPosition.current.set(...config.initialPosition);
-      lastReportedPosition.current.set(...config.initialPosition);
+      const pt = SPAWN_POINTS[Math.floor(Math.random() * SPAWN_POINTS.length)];
+      meshRef.current.position.set(...pt);
+      lastPosition.current.set(...pt);
+      lastReportedPosition.current.set(...pt);
     }
     prevIsDownedRef.current = isDowned;
-  }, [isDowned, config.initialPosition, meshRef]);
+  }, [isDowned, meshRef]);
 
   // Handle being tagged by target
   useEffect(() => {

--- a/src/lib/constants/spawnPoints.ts
+++ b/src/lib/constants/spawnPoints.ts
@@ -1,0 +1,35 @@
+/** Spread spawn points for deathmatch/CTF — avoids center, mid-field crates, and corner bunkers. */
+export const SPAWN_POINTS: [number, number, number][] = [
+  [-12, 0.5, 0],
+  [12, 0.5, 0],
+  [0, 0.5, -12],
+  [0, 0.5, 12],
+  [-10, 0.5, 10],
+  [10, 0.5, 10],
+  [-10, 0.5, -10],
+  [10, 0.5, -10],
+];
+
+/**
+ * Pick the spawn point farthest from all given enemy positions.
+ * Falls back to a random point if no enemies are provided.
+ */
+export function pickSafeSpawn(
+  enemyPositions: [number, number, number][],
+): [number, number, number] {
+  if (enemyPositions.length === 0) {
+    return SPAWN_POINTS[Math.floor(Math.random() * SPAWN_POINTS.length)];
+  }
+  let best = SPAWN_POINTS[0];
+  let bestMinDist = -1;
+  for (const pt of SPAWN_POINTS) {
+    const minDist = Math.min(
+      ...enemyPositions.map(([ex, , ez]) => Math.hypot(pt[0] - ex, pt[2] - ez)),
+    );
+    if (minDist > bestMinDist) {
+      bestMinDist = minDist;
+      best = pt;
+    }
+  }
+  return best;
+}


### PR DESCRIPTION
## Summary
- **spawnPoints.ts**: 8 spread spawn points around the arena (avoids center, mid-field crates, corner bunkers) + `pickSafeSpawn()` helper that returns the point farthest from all alive enemy positions
- **PlayerCharacter**: on respawn, picks the safest spawn point away from alive enemies instead of always returning to [0, 0.5, 0] at center
- **useBotAI**: on respawn, picks a random spawn from the 8-point pool instead of returning to the bot's fixed initial position

## Test plan
- [x] 879 tests pass (Docker)
- [x] Lint clean, TS clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)