### PR TITLE
Phase AN: floating bot name labels above health bars (#294)

### DIFF
--- a/src/__tests__/Lobby.test.tsx
+++ b/src/__tests__/Lobby.test.tsx
@@ -44,6 +44,9 @@ vi.mock("@react-three/drei", () => {
     Text: ({ children }: { children: React.ReactNode }) => (
       <span>{children}</span>
     ),
+    Billboard: ({ children }: { children: React.ReactNode }) => (
+      <span>{children}</span>
+    ),
     Stats: () => <div data-testid="stats" />,
   };
 });

--- a/src/__tests__/Solo.test.tsx
+++ b/src/__tests__/Solo.test.tsx
@@ -25,6 +25,9 @@ vi.mock("@react-three/drei", () => ({
   Text: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="text">{children}</div>
   ),
+  Billboard: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="billboard">{children}</div>
+  ),
   Stats: () => <div data-testid="stats" />,
   OrbitControls: () => <div data-testid="orbit-controls" />,
 }));

--- a/src/components/characters/BotCharacter.tsx
+++ b/src/components/characters/BotCharacter.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useRef, useEffect } from "react";
 import * as THREE from "three";
-import { Billboard } from "@react-three/drei";
+import { Billboard, Text } from "@react-three/drei";
 import SpacemanModel from "../SpacemanModel";
 import CollisionSystem from "../CollisionSystem";
 import { GameState } from "../GameManager";
@@ -144,19 +144,30 @@ export const BotCharacter: React.FC<BotCharacterProps> = ({
         <sphereGeometry args={[0.12, 8, 8]} />
         <meshBasicMaterial color={isIt ? "#ff4444" : labelColor || color} />
       </mesh>
+      {/* Floating name label — always faces camera */}
+      <Billboard position={[0, 2.15, 0]}>
+        <Text
+          fontSize={0.22}
+          color={isIt ? "#ff4444" : "#ffffff"}
+          anchorX="center"
+          anchorY="middle"
+          outlineWidth={0.03}
+          outlineColor="#000000"
+        >
+          {config.label}
+        </Text>
+      </Billboard>
       {/* Health bar — always faces camera via Billboard, hidden in tag mode */}
       {showHealthBar && (
-         
         <Billboard position={[0, 1.9, 0]}>
           {/* Background track */}
-          { }
+          {}
           <mesh>
             <boxGeometry args={[BAR_W, 0.08, 0.01]} />
             <meshBasicMaterial color="#111111" />
           </mesh>
           {/* Fill — left-anchored, shrinks right as health drops */}
           {fillW > 0 && (
-             
             <mesh position={[fillX, 0, 0.006]}>
               <boxGeometry args={[fillW, 0.08, 0.01]} />
               <meshBasicMaterial color={fillColor} />

--- a/src/pages/Solo/components/__tests__/Players.test.tsx
+++ b/src/pages/Solo/components/__tests__/Players.test.tsx
@@ -24,6 +24,9 @@ vi.mock("@react-three/drei", () => ({
   Text: ({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   ),
+  Billboard: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
 }));
 
 describe("Players", () => {


### PR DESCRIPTION
## Summary
- **BotCharacter**: add `Billboard` + `Text` name label at Y+2.15 showing `config.label` (Bot1/Bot2/Bot3)
- Label is white normally, red when the bot is IT in tag mode
- Sits above the existing health bar strip in combat modes
- Uses `@react-three/drei` `Text` with black outline for readability against any background

## Test plan
- [x] 879 tests pass (Docker)
- [x] Lint clean, TS clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)