### PR TITLE
Phase AQ: SMG weapon — rapid-fire 12dmg, 40 ammo, key 5 (#297)

### DIFF
--- a/src/components/GameUI.tsx
+++ b/src/components/GameUI.tsx
@@ -504,7 +504,7 @@ const GameUI: React.FC<GameUIProps> = ({
                   currentPlayer.currentAmmo === undefined
                     ? "∞"
                     : currentPlayer.currentAmmo}
-                  ] [1/2/3]
+                  ] [1-5]
                 </div>
               )}
 
@@ -584,7 +584,7 @@ const GameUI: React.FC<GameUIProps> = ({
                   currentPlayer.currentAmmo === undefined
                     ? "∞"
                     : currentPlayer.currentAmmo}
-                  ] [1/2/3]
+                  ] [1-5]
                 </div>
               )}
 

--- a/src/components/characters/PlayerCharacter.tsx
+++ b/src/components/characters/PlayerCharacter.tsx
@@ -18,6 +18,7 @@ import {
   KEY_2,
   KEY_3,
   KEY_4,
+  KEY_5,
 } from "../utils";
 import SpacemanModel from "../SpacemanModel";
 import { getSoundManager } from "../SoundManager";
@@ -172,6 +173,7 @@ export const PlayerCharacter = React.forwardRef<
   const prevKey2Ref = React.useRef(false);
   const prevKey3Ref = React.useRef(false);
   const prevKey4Ref = React.useRef(false);
+  const prevKey5Ref = React.useRef(false);
 
   // Equip the laser blaster by default and surface the equipped weapon to the HUD.
   React.useEffect(() => {
@@ -470,11 +472,12 @@ export const PlayerCharacter = React.forwardRef<
       }
     }
 
-    // Weapon switching: rising-edge detection for 1 (laser), 2 (shotgun), 3 (rocket), 4 (grenade).
+    // Weapon switching: rising-edge detection for 1 (laser), 2 (shotgun), 3 (rocket), 4 (grenade), 5 (smg).
     const key1 = keysPressedRef.current[KEY_1] ?? false;
     const key2 = keysPressedRef.current[KEY_2] ?? false;
     const key3 = keysPressedRef.current[KEY_3] ?? false;
     const key4 = keysPressedRef.current[KEY_4] ?? false;
+    const key5 = keysPressedRef.current[KEY_5] ?? false;
     const myId = socketClient?.id || currentPlayerId;
     if (key1 && !prevKey1Ref.current) {
       weaponManagerRef.current.equip("laser");
@@ -504,10 +507,18 @@ export const PlayerCharacter = React.forwardRef<
         currentAmmo: weaponManagerRef.current.getAmmo("grenade"),
       });
     }
+    if (key5 && !prevKey5Ref.current) {
+      weaponManagerRef.current.equip("smg");
+      gameManager?.updatePlayer(myId, {
+        equippedWeaponId: "smg",
+        currentAmmo: weaponManagerRef.current.getAmmo("smg"),
+      });
+    }
     prevKey1Ref.current = key1;
     prevKey2Ref.current = key2;
     prevKey3Ref.current = key3;
     prevKey4Ref.current = key4;
+    prevKey5Ref.current = key5;
 
     // Fire the equipped weapon while left-click is held (rate-limited by
     // WeaponManager's per-shooter cooldown).

--- a/src/components/combat/WeaponManager.ts
+++ b/src/components/combat/WeaponManager.ts
@@ -49,6 +49,14 @@ export const WEAPONS: Record<string, WeaponConfig> = {
     splashRadius: 7,
     splashDamage: 75,
   },
+  smg: {
+    id: "smg",
+    name: "SMG",
+    damage: 12,
+    range: 18,
+    cooldownMs: 120,
+    maxAmmo: 40,
+  },
 };
 
 /**

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -10,6 +10,7 @@ export const KEY_1 = "1";
 export const KEY_2 = "2";
 export const KEY_3 = "3";
 export const KEY_4 = "4";
+export const KEY_5 = "5";
 export const DIRECTIONS = [W, A, S, D, Q, E];
 
 export class KeyDisplay {

--- a/src/components/world/WeaponPickups.tsx
+++ b/src/components/world/WeaponPickups.tsx
@@ -47,6 +47,12 @@ export const PICKUP_DEFS: PickupDef[] = [
     weaponId: "grenade",
     color: "#44ff00",
   },
+  {
+    id: "pickup-smg",
+    position: [-14, 0.8, 0],
+    weaponId: "smg",
+    color: "#ff44cc",
+  },
 ];
 
 type PickupState = {


### PR DESCRIPTION
## Summary
- **WeaponManager**: new `smg` weapon (12dmg, 120ms cooldown, 40 ammo, 18u range) — fills the rapid-fire role missing between laser and shotgun
- **utils**: export `KEY_5` constant
- **PlayerCharacter**: wire key `5` to smg equip with proper rising-edge detection
- **WeaponPickups**: pink smg crate at `[-14, 0.8, 0]` on the west side of the arena
- **GameUI**: weapon key hint updated from `[1/2/3]` to `[1-5]`

## Test plan
- [x] 879 tests pass (Docker)
- [x] Lint clean, TS clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)