### PR TITLE
Phase AR: Bot-1 equipped with SMG — rapid-fire rusher archetype (#298)

### DIFF
--- a/src/lib/constants/botConfigs.ts
+++ b/src/lib/constants/botConfigs.ts
@@ -7,21 +7,21 @@
 import type { BotConfig } from "../../components/characters/useBotAI";
 
 /**
- * Bot 1 Configuration - Balanced bot
- * Good for testing, not too fast or slow
+ * Bot 1 Configuration - Aggressive SMG rusher
+ * Fast bot that gets in close and sprays the SMG
  */
 export const BOT1_CONFIG: BotConfig = {
-  botSpeed: 3.0,
-  sprintSpeed: 4.5,
+  botSpeed: 3.5,
+  sprintSpeed: 5.0,
   fleeSpeed: 1.3,
   tagCooldown: 500,
   tagDistance: 1.0,
-  pauseAfterTag: 3000, // 3 second freeze when tagged (matches player freeze)
+  pauseAfterTag: 3000,
   sprintDuration: 3000,
   sprintCooldown: 2000,
   chaseRadius: 15,
   initialPosition: [-5, 0.5, -5],
-  missChance: 0.38,
+  missChance: 0.22,
   label: "Bot1",
 };
 

--- a/src/pages/Solo/components/Bots.tsx
+++ b/src/pages/Solo/components/Bots.tsx
@@ -266,7 +266,7 @@ const Bots: React.FC<
   ]);
 
   // Each bot gets its own WeaponManager so they can use different weapons.
-  // Bot-1: Pulse Shotgun, Bot-2: Rocket Launcher, Bot-3: Frag Grenade.
+  // Bot-1: SMG (rapid-fire spray), Bot-2: Rocket Launcher, Bot-3: Frag Grenade.
   const bot1WeaponsRef = useRef<WeaponManager | null>(null);
   const bot2WeaponsRef = useRef<WeaponManager | null>(null);
   const bot3WeaponsRef = useRef<WeaponManager | null>(null);
@@ -298,7 +298,7 @@ const Bots: React.FC<
         const startWeapon = isTagMode
           ? "laser"
           : botId === "bot-1"
-            ? "shotgun"
+            ? "smg"
             : botId === "bot-2"
               ? "rocket"
               : "grenade";

--- a/src/pages/Solo/components/__tests__/Bots.test.tsx
+++ b/src/pages/Solo/components/__tests__/Bots.test.tsx
@@ -237,18 +237,18 @@ describe("Bots", () => {
     render(<Bots {...props} />);
     const fire = botPropsByRender[0].onFireAtTarget as () => void;
 
-    // bot-1 uses the Pulse Shotgun (damage 25, cooldown 1000ms)
+    // bot-1 uses the SMG (damage 12, cooldown 120ms)
     fire();
-    expect(gm.getPlayers().get("player-1")?.health).toBe(75);
+    expect(gm.getPlayers().get("player-1")?.health).toBe(88);
 
-    // Still within the shotgun's 1000ms cooldown - the shot is gated.
+    // Still within the SMG's 120ms cooldown - the shot is gated.
     fire();
-    expect(gm.getPlayers().get("player-1")?.health).toBe(75);
+    expect(gm.getPlayers().get("player-1")?.health).toBe(88);
 
     // Cooldown elapsed - the next shot lands.
     nowSpy.mockReturnValue(6001);
     fire();
-    expect(gm.getPlayers().get("player-1")?.health).toBe(50);
+    expect(gm.getPlayers().get("player-1")?.health).toBe(76);
   });
 
   it("marks a bot as downed while it awaits respawn in deathmatch", () => {
@@ -328,8 +328,8 @@ describe("Bots", () => {
     const fire = botPropsByRender[0].onFireAtTarget as () => void;
 
     fire();
-    // bot-1 equips the Pulse Shotgun (damage 25), so 100 - 25 = 75
-    expect(gm.getPlayers().get("player-1")?.health).toBe(75);
+    // bot-1 equips the SMG (damage 12), so 100 - 12 = 88
+    expect(gm.getPlayers().get("player-1")?.health).toBe(88);
 
     nowSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- **Bots.tsx**: bot-1 now starts with `smg` instead of `shotgun` in deathmatch/CTF
- **botConfigs**: `BOT1_CONFIG` speed bumped (3.0→3.5 walk, 4.5→5.0 sprint) and `missChance` lowered (0.38→0.22) to suit SMG's close-range spray role — more accurate up close, high fire rate does the work
- **Archetypes**: Bot-1 SMG rusher / Bot-2 Rocket burst / Bot-3 Grenade AOE — gives each bot a distinct threat profile

## Test plan
- [x] 879 tests pass (Docker)
- [x] Lint clean, TS clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)