### PR TITLE
Phase AS: SMG beam color — pink #ff44cc to match pickup crate (#299)

### DIFF
--- a/src/components/characters/PlayerCharacter.tsx
+++ b/src/components/characters/PlayerCharacter.tsx
@@ -558,7 +558,9 @@ export const PlayerCharacter = React.forwardRef<
               ? "#44ff00"
               : wid === "shotgun"
                 ? "#ff7700"
-                : "#33ffe6";
+                : wid === "smg"
+                  ? "#ff44cc"
+                  : "#33ffe6";
         laserBeamRef.current.visible = true;
         laserBeamRef.current.position
           .copy(fireOrigin)


### PR DESCRIPTION
## Summary
- **PlayerCharacter**: SMG weapon now emits a pink (`#ff44cc`) beam matching its pickup crate color, distinguishing it from laser cyan (`#33ffe6`), shotgun orange, rocket red, and grenade green
- Weapon beam color palette is now: laser=cyan, shotgun=orange, rocket=red, grenade=green, smg=pink

## Test plan
- [x] 879 tests pass (Docker)
- [x] Lint clean, TS clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)