### PR TITLE
Phase AT: per-weapon HUD colors + numeric ammo for large pools (#300)

### DIFF
--- a/src/components/GameUI.tsx
+++ b/src/components/GameUI.tsx
@@ -965,9 +965,13 @@ const GameUI: React.FC<GameUIProps> = ({
                   const wColor =
                     currentPlayer.equippedWeaponId === "rocket"
                       ? "#ff4422"
-                      : currentPlayer.equippedWeaponId === "shotgun"
-                        ? "#ff9933"
-                        : "#33ffe6";
+                      : currentPlayer.equippedWeaponId === "grenade"
+                        ? "#44ff00"
+                        : currentPlayer.equippedWeaponId === "shotgun"
+                          ? "#ff9933"
+                          : currentPlayer.equippedWeaponId === "smg"
+                            ? "#ff44cc"
+                            : "#33ffe6";
                   return (
                     <>
                       <span style={{ color: wColor }}>
@@ -976,7 +980,7 @@ const GameUI: React.FC<GameUIProps> = ({
                       <span style={{ color: "#aaaaaa", letterSpacing: "1px" }}>
                         {ammo === null || ammo === undefined
                           ? "∞"
-                          : maxAmmo
+                          : maxAmmo && maxAmmo <= 10
                             ? Array.from({ length: maxAmmo }, (_, i) => (
                                 <span
                                   key={i}
@@ -985,7 +989,7 @@ const GameUI: React.FC<GameUIProps> = ({
                                   ●
                                 </span>
                               ))
-                            : ammo}
+                            : `${ammo}`}
                       </span>
                       <span style={{ color: "#555", fontSize: "10px" }}>
                         [1/2/3]


### PR DESCRIPTION
## Summary
- **GameUI bottom-center weapon display**: weapon name and ammo now use per-weapon colors matching beam colors — rocket red, grenade green, shotgun orange, SMG pink, laser cyan
- **Ammo display logic**: weapons with `maxAmmo > 10` (i.e. SMG's 40 rounds) now show a number instead of dots to avoid a wall of 40 pips being unreadable

## Test plan
- [x] 879 tests pass (Docker)
- [x] Lint clean, TS clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)