### PR TITLE
Phase AW: dynamic crosshair spread — expands on fire, SMG spreads most (#303)

### DIFF
--- a/src/components/GameUI.tsx
+++ b/src/components/GameUI.tsx
@@ -125,6 +125,32 @@ const GameUI: React.FC<GameUIProps> = ({
     return () => window.removeEventListener("player-hit-landed", handle);
   }, []);
 
+  // Crosshair spread: expands on fire, decays back to 0.
+  const [crosshairSpread, setCrosshairSpread] = React.useState(0);
+  const spreadDecayRef = React.useRef<ReturnType<typeof setInterval> | null>(
+    null,
+  );
+  React.useEffect(() => {
+    const onFired = (e: unknown) => {
+      const weaponId = (e as { detail: { weaponId: string } }).detail.weaponId;
+      const addSpread =
+        weaponId === "smg" ? 8 : weaponId === "shotgun" ? 6 : 3;
+      setCrosshairSpread((prev) => Math.min(prev + addSpread, 24));
+      if (spreadDecayRef.current) clearInterval(spreadDecayRef.current);
+      spreadDecayRef.current = setInterval(() => {
+        setCrosshairSpread((prev) => {
+          if (prev <= 0) {
+            if (spreadDecayRef.current) clearInterval(spreadDecayRef.current);
+            return 0;
+          }
+          return prev - 2;
+        });
+      }, 50);
+    };
+    window.addEventListener("weapon-fired", onFired);
+    return () => window.removeEventListener("weapon-fired", onFired);
+  }, []);
+
   // Tab scoreboard overlay
   const [showScoreboard, setShowScoreboard] = React.useState(false);
   React.useEffect(() => {
@@ -838,32 +864,64 @@ const GameUI: React.FC<GameUIProps> = ({
                 transform: "translate(-50%, -50%)",
                 pointerEvents: "none",
                 zIndex: 997,
-                width: "20px",
-                height: "20px",
+                width: `${20 + crosshairSpread * 2}px`,
+                height: `${20 + crosshairSpread * 2}px`,
               }}
             >
-              {/* Horizontal bar */}
+              {/* Horizontal bar — left segment */}
               <div
                 style={{
                   position: "absolute",
-                  top: "9px",
+                  top: "50%",
                   left: 0,
-                  right: 0,
+                  width: `${6 + crosshairSpread}px`,
                   height: "2px",
+                  marginTop: "-1px",
                   backgroundColor: hitMarker
                     ? "rgba(255,60,60,1)"
                     : "rgba(255,255,255,0.85)",
                   transition: "background-color 0.05s",
                 }}
               />
-              {/* Vertical bar */}
+              {/* Horizontal bar — right segment */}
               <div
                 style={{
                   position: "absolute",
-                  left: "9px",
+                  top: "50%",
+                  right: 0,
+                  width: `${6 + crosshairSpread}px`,
+                  height: "2px",
+                  marginTop: "-1px",
+                  backgroundColor: hitMarker
+                    ? "rgba(255,60,60,1)"
+                    : "rgba(255,255,255,0.85)",
+                  transition: "background-color 0.05s",
+                }}
+              />
+              {/* Vertical bar — top segment */}
+              <div
+                style={{
+                  position: "absolute",
+                  left: "50%",
                   top: 0,
+                  width: "2px",
+                  height: `${6 + crosshairSpread}px`,
+                  marginLeft: "-1px",
+                  backgroundColor: hitMarker
+                    ? "rgba(255,60,60,1)"
+                    : "rgba(255,255,255,0.85)",
+                  transition: "background-color 0.05s",
+                }}
+              />
+              {/* Vertical bar — bottom segment */}
+              <div
+                style={{
+                  position: "absolute",
+                  left: "50%",
                   bottom: 0,
                   width: "2px",
+                  height: `${6 + crosshairSpread}px`,
+                  marginLeft: "-1px",
                   backgroundColor: hitMarker
                     ? "rgba(255,60,60,1)"
                     : "rgba(255,255,255,0.85)",

--- a/src/components/characters/PlayerCharacter.tsx
+++ b/src/components/characters/PlayerCharacter.tsx
@@ -542,6 +542,13 @@ export const PlayerCharacter = React.forwardRef<
         now,
       });
 
+      if (fireResult && typeof window !== "undefined") {
+        window.dispatchEvent(
+          new window.CustomEvent("weapon-fired", {
+            detail: { weaponId: fireResult.weapon.id },
+          }),
+        );
+      }
       if (fireResult && laserBeamRef.current) {
         const beamLength = fireResult.hit?.distance ?? fireResult.weapon.range;
         const wid = fireResult.weapon.id;


### PR DESCRIPTION
## Summary
- **PlayerCharacter**: dispatches a `weapon-fired` CustomEvent (with `weaponId`) on each successful shot
- **GameUI**: listens for `weapon-fired` and increases `crosshairSpread` (+8 SMG, +6 shotgun, +3 others, max 24), then decays 2px every 50ms
- **Crosshair**: redesigned from two solid bars into 4 separate segments with a center gap that grows with spread — laser stays tight, SMG blooms wide

## Test plan
- [x] 879 tests pass (Docker)
- [x] Lint clean, TS clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)