### PR TITLE
Phase AX: CTF base markers — glowing disc + flag pole at each team base (#305)

### DIFF
--- a/src/components/world/CTFBases.tsx
+++ b/src/components/world/CTFBases.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { TEAM_A_BASE, TEAM_B_BASE } from "../gameModes/CTFMode";
+
+const BASE_RADIUS = 2.5;
+
+function Base({
+  position,
+  color,
+}: {
+  position: [number, number, number];
+  color: string;
+}) {
+  return (
+    <group position={position}>
+      {/* Glowing floor disc */}
+      <mesh position={[0, -0.45, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[BASE_RADIUS, 32]} />
+        <meshBasicMaterial color={color} opacity={0.35} transparent />
+      </mesh>
+      {/* Thin rim ring */}
+      <mesh position={[0, -0.44, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <ringGeometry args={[BASE_RADIUS - 0.1, BASE_RADIUS, 32]} />
+        <meshBasicMaterial color={color} opacity={0.85} transparent />
+      </mesh>
+      {/* Vertical pole */}
+      <mesh position={[0, 0.75, 0]}>
+        <cylinderGeometry args={[0.05, 0.05, 1.5, 8]} />
+        <meshBasicMaterial color={color} />
+      </mesh>
+      {/* Flag panel on pole */}
+      <mesh position={[0.25, 1.3, 0]}>
+        <boxGeometry args={[0.5, 0.3, 0.02]} />
+        <meshBasicMaterial color={color} />
+      </mesh>
+    </group>
+  );
+}
+
+const CTFBases: React.FC = () => (
+  <>
+    <Base position={TEAM_A_BASE} color="#3388ff" />
+    <Base position={TEAM_B_BASE} color="#ff3333" />
+  </>
+);
+
+export default CTFBases;

--- a/src/pages/Solo/components/SoloScene.tsx
+++ b/src/pages/Solo/components/SoloScene.tsx
@@ -7,6 +7,7 @@ import WeaponPickups from "../../../components/world/WeaponPickups";
 import HealthPickups from "../../../components/world/HealthPickups";
 import ExplosionVFX from "../../../components/world/ExplosionVFX";
 import DamageNumbers from "../../../components/world/DamageNumbers";
+import CTFBases from "../../../components/world/CTFBases";
 import type { SoloSceneProps } from "./SoloScene.types";
 
 type Props = SoloSceneProps;
@@ -120,6 +121,7 @@ export const SoloScene: React.FC<Props> = ({
       />
       <ExplosionVFX />
       <DamageNumbers />
+      {gameState.mode === "ctf" && <CTFBases />}
     </Canvas>
   );
 };


### PR DESCRIPTION
## Summary
- **CTFBases** (new component): renders a blue base at `[-15, 0.5, 0]` (team A) and a red base at `[15, 0.5, 0]` (team B), each with a translucent floor disc, solid rim ring, vertical pole, and small flag panel
- **SoloScene**: imports CTFBases and renders it only when `gameState.mode === 'ctf'`
- Players can now navigate to the visible base to return a captured flag instead of guessing coordinates

## Test plan
- [x] 879 tests pass (Docker)
- [x] Lint clean, TS clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)