### PR TITLE
Phase AY: passive health regen — 5hp/s after 5s without damage (#306)

### DIFF
--- a/src/components/GameManager.ts
+++ b/src/components/GameManager.ts
@@ -79,6 +79,8 @@ export interface Player {
   spawnProtectedUntil?: number;
   /** Consecutive kills without dying (resets on death). */
   currentKillStreak?: number;
+  /** Timestamp (ms) of the most recent damage taken — used for passive health regen delay. */
+  lastDamageAt?: number;
 }
 
 export class GameManager {

--- a/src/components/gameModes/DeathmatchMode.ts
+++ b/src/components/gameModes/DeathmatchMode.ts
@@ -68,6 +68,20 @@ export class DeathmatchMode implements GameModeHandler {
       ) {
         player.spawnProtectedUntil = undefined;
       }
+      // Passive regen: 5hp/s after 5s without damage, up to half max health.
+      const REGEN_DELAY_MS = 5000;
+      const REGEN_CAP = Math.floor((player.maxHealth ?? this.DEFAULT_MAX_HEALTH) / 2);
+      if (
+        player.respawnAt === undefined &&
+        (player.health ?? 0) < REGEN_CAP &&
+        (player.lastDamageAt === undefined ||
+          now - player.lastDamageAt >= REGEN_DELAY_MS)
+      ) {
+        player.health = Math.min(
+          REGEN_CAP,
+          (player.health ?? 0) + 5 * deltaTime,
+        );
+      }
     });
 
     if (
@@ -102,6 +116,7 @@ export class DeathmatchMode implements GameModeHandler {
     const maxHealth = target.maxHealth ?? this.DEFAULT_MAX_HEALTH;
     const currentHealth = target.health ?? maxHealth;
     target.health = Math.max(0, currentHealth - damage);
+    target.lastDamageAt = Date.now();
 
     if (target.health === 0) {
       this.applyKill(
@@ -133,6 +148,7 @@ export class DeathmatchMode implements GameModeHandler {
           0,
           (nearby.health ?? nearbyMax) - splashDamage,
         );
+        nearby.lastDamageAt = Date.now();
         if (nearby.health === 0) {
           this.applyKill(
             attackerId,


### PR DESCRIPTION
## Summary
- **GameManager**: adds `lastDamageAt?: number` to the `Player` interface
- **DeathmatchMode**: stamps `lastDamageAt = Date.now()` on direct hits and splash damage
- **DeathmatchMode `onTick`**: when a player is alive and has been undamaged for ≥5s, regenerates 5hp/s up to half max health (50 HP for default 100 max)

This prevents chip damage from being permanently debilitating and rewards smart play/positioning while keeping the game intense (regen stops at 50hp, not full).

## Test plan
- [x] 879 tests pass (Docker)
- [x] Lint clean, TS clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)