### PR TITLE
Phase AZ: arena boundary walls + BOT4_CONFIG sniper preset (#307)

### DIFF
--- a/src/lib/constants/botConfigs.ts
+++ b/src/lib/constants/botConfigs.ts
@@ -64,6 +64,30 @@ export const BOT3_CONFIG: BotConfig = {
 };
 
 /**
+ * Bot 4 Configuration - Laser sniper
+ * Slow, accurate, long-range threat using the default laser
+ */
+export const BOT4_CONFIG: BotConfig = {
+  botSpeed: 2.0,
+  sprintSpeed: 2.8,
+  fleeSpeed: 0.8,
+  tagCooldown: 500,
+  tagDistance: 1.0,
+  pauseAfterTag: 3000,
+  sprintDuration: 2000,
+  sprintCooldown: 3000,
+  chaseRadius: 25,
+  initialPosition: [8, 0.5, 8],
+  missChance: 0.12,
+  label: "Bot4",
+};
+
+/**
  * All bot configurations for easy iteration
  */
-export const BOT_CONFIGS = [BOT1_CONFIG, BOT2_CONFIG, BOT3_CONFIG] as const;
+export const BOT_CONFIGS = [
+  BOT1_CONFIG,
+  BOT2_CONFIG,
+  BOT3_CONFIG,
+  BOT4_CONFIG,
+] as const;

--- a/src/pages/Solo/components/Environment.tsx
+++ b/src/pages/Solo/components/Environment.tsx
@@ -57,6 +57,21 @@ const Environment: React.FC<Props> = ({ qualitySettings, rockPositions }) => {
         </mesh>
       ))}
 
+      {/* Arena boundary walls at ±50 (matching CollisionSystem worldSize) */}
+      {(
+        [
+          [0, 2, 50, 100, 4, 1], // north wall
+          [0, 2, -50, 100, 4, 1], // south wall
+          [50, 2, 0, 1, 4, 100], // east wall
+          [-50, 2, 0, 1, 4, 100], // west wall
+        ] as [number, number, number, number, number, number][]
+      ).map(([x, y, z, w, h, d], i) => (
+        <mesh key={`wall-${i}`} position={[x, y, z]}>
+          <boxGeometry args={[w, h, d]} />
+          <meshStandardMaterial color="#334455" roughness={0.95} metalness={0.1} />
+        </mesh>
+      ))}
+
       {/* Mid-field cover crates — symmetric cross, match CollisionSystem entries */}
       {(
         [


### PR DESCRIPTION
## Summary
- **Environment**: visible boundary walls at ±50 on X/Z axes (matching CollisionSystem's `worldSize = 50`) — dark slate color, 4 units tall, give the arena defined edges so the play space feels enclosed
- **botConfigs**: `BOT4_CONFIG` — laser sniper (2.0 walk, 2.8 sprint, 0.12 missChance, 25u chaseRadius); added to `BOT_CONFIGS` array for future bot-4 wiring in `Bots.tsx`

## Test plan
- [x] 879 tests pass (Docker)
- [x] Lint clean, TS clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)