### PR TITLE
Phase BC: auto-restart combat modes after 7s results screen

### DIFF
--- a/src/components/GameUI.tsx
+++ b/src/components/GameUI.tsx
@@ -12,6 +12,8 @@ interface GameUIProps {
   onEndGame: () => void;
   botDebugMode?: boolean;
   onToggleDebug?: () => void;
+  /** Seconds until auto-restart fires; null = no auto-restart pending. */
+  autoRestartSecondsLeft?: number | null;
 }
 
 const GameUI: React.FC<GameUIProps> = ({
@@ -22,6 +24,7 @@ const GameUI: React.FC<GameUIProps> = ({
   onEndGame,
   botDebugMode = false,
   onToggleDebug,
+  autoRestartSecondsLeft = null,
 }) => {
   // Detect mobile viewport and landscape orientation
   const [isMobile, setIsMobile] = React.useState(window.innerWidth <= 768);
@@ -1277,6 +1280,22 @@ const GameUI: React.FC<GameUIProps> = ({
             </div>
           ))}
         </div>
+
+        {autoRestartSecondsLeft !== null && (
+          <div
+            style={{
+              fontFamily: "monospace",
+              fontSize: isMinimal ? "9px" : "11px",
+              color: "#aaaaaa",
+              marginBottom: "8px",
+              letterSpacing: "1px",
+            }}
+          >
+            {autoRestartSecondsLeft > 0
+              ? `AUTO-RESTART IN ${autoRestartSecondsLeft}s`
+              : "RESTARTING..."}
+          </div>
+        )}
 
         <button
           onClick={() => onStartGame(gameState.mode)}

--- a/src/pages/Solo.tsx
+++ b/src/pages/Solo.tsx
@@ -98,6 +98,10 @@ const Solo: React.FC = () => {
     null,
   );
 
+  // Auto-restart countdown after game over in combat modes (deathmatch/ctf).
+  const [autoRestartSecondsLeft, setAutoRestartSecondsLeft] = useState<number | null>(null);
+  const autoRestartIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
   // Mobile jetpack trigger (set to true when double-tap detected)
   const mobileJetpackTrigger = useRef(false);
 
@@ -538,6 +542,39 @@ const Solo: React.FC = () => {
     };
   }, [botDebugMode, gameState.isActive, gameState.mode, syncGameState]);
 
+  // Auto-restart combat modes (deathmatch/ctf) after a 7-second results delay.
+  useEffect(() => {
+    const isCombat = gameState.mode === "deathmatch" || gameState.mode === "ctf";
+    if (!gameState.isActive && gameState.gameResults && gameState.gameResults.length > 0 && isCombat) {
+      const AUTO_RESTART_SECS = 7;
+      setAutoRestartSecondsLeft(AUTO_RESTART_SECS);
+      let remaining = AUTO_RESTART_SECS;
+      autoRestartIntervalRef.current = setInterval(() => {
+        remaining--;
+        setAutoRestartSecondsLeft(remaining);
+        if (remaining <= 0) {
+          clearInterval(autoRestartIntervalRef.current!);
+          autoRestartIntervalRef.current = null;
+          setAutoRestartSecondsLeft(null);
+          handleStartGame(gameState.mode);
+        }
+      }, 1000);
+    } else {
+      if (autoRestartIntervalRef.current) {
+        clearInterval(autoRestartIntervalRef.current);
+        autoRestartIntervalRef.current = null;
+      }
+      setAutoRestartSecondsLeft(null);
+    }
+    return () => {
+      if (autoRestartIntervalRef.current) {
+        clearInterval(autoRestartIntervalRef.current);
+        autoRestartIntervalRef.current = null;
+      }
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gameState.isActive, gameState.mode]);
+
   // Add/remove Bot2 when debug mode toggles
   useEffect(() => {
     if (!gameManager.current) return;
@@ -827,6 +864,7 @@ const Solo: React.FC = () => {
         onEndGame={handleEndGame}
         botDebugMode={botDebugMode}
         onToggleDebug={() => setBotDebugMode((prev) => !prev)}
+        autoRestartSecondsLeft={autoRestartSecondsLeft}
         notifications={notifications}
         currentFPS={currentFPS}
         setQuality={setQuality}

--- a/src/pages/Solo/components/SoloHUD.tsx
+++ b/src/pages/Solo/components/SoloHUD.tsx
@@ -26,6 +26,7 @@ interface SoloHUDProps {
   onEndGame: () => void;
   botDebugMode: boolean;
   onToggleDebug: () => void;
+  autoRestartSecondsLeft?: number | null;
   notifications: Array<{ id: string; message: string; type: string }>;
   addNotification?: (message: string, type?: string) => void;
   currentFPS: number;
@@ -56,6 +57,7 @@ const SoloHUD: React.FC<SoloHUDProps> = ({
   onEndGame,
   botDebugMode,
   onToggleDebug,
+  autoRestartSecondsLeft,
   notifications,
   currentFPS,
   setQuality,
@@ -95,6 +97,7 @@ const SoloHUD: React.FC<SoloHUDProps> = ({
         onEndGame={onEndGame}
         botDebugMode={botDebugMode}
         onToggleDebug={onToggleDebug}
+        autoRestartSecondsLeft={autoRestartSecondsLeft}
       />
 
       {/* Notifications */}


### PR DESCRIPTION
## Summary
- After deathmatch/CTF ends, a 7-second countdown appears on the results screen
- Game automatically restarts the same mode when countdown reaches 0
- Countdown resets if the player manually clicks Play Again
- GameUI gets optional `autoRestartSecondsLeft` prop (null = no countdown shown)
- SoloHUD forwards the prop through; Solo.tsx owns the interval and state

## Test plan
- [x] All 879 tests pass (133 files)
- [ ] Start deathmatch — let it end (kill limit) — confirm "AUTO-RESTART IN 7s" shows and counts down
- [ ] Confirm game restarts automatically at 0 without clicking Play Again
- [ ] Confirm clicking Play Again resets countdown and restarts immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)