### PR TITLE
Phase BE: bot jumping in deathmatch — bots hop every 2.5–4.5s to dodge shots

### DIFF
--- a/src/components/characters/useBotAI.ts
+++ b/src/components/characters/useBotAI.ts
@@ -118,6 +118,11 @@ export function useBotAI({
   // Combat strafe: bots dodge left/right while firing to be harder to hit.
   const strafeSign = useRef<1 | -1>(1);
   const nextStrafeChangeTime = useRef(0);
+  // Bot jump: vertical velocity applied during jumps.
+  const jumpVelocity = useRef(0);
+  const nextJumpTime = useRef(0);
+  const JUMP_SPEED = 6;
+  const GRAVITY = 18;
 
   // Teleport bot back to a random spawn point when it respawns after being downed.
   const prevIsDownedRef = useRef(isDowned);
@@ -341,6 +346,21 @@ export function useBotAI({
         .subVectors(targetPos, botPos)
         .normalize();
       meshRef.current.rotation.y = Math.atan2(direction.x, direction.z);
+
+      // Bot jumps occasionally to be harder to hit (every 2.5–4.5s).
+      const groundY = config.initialPosition[1];
+      if (botPos.y <= groundY + 0.05 && now >= nextJumpTime.current) {
+        jumpVelocity.current = JUMP_SPEED;
+        nextJumpTime.current = now + 2500 + Math.random() * 2000;
+      }
+      if (jumpVelocity.current !== 0 || botPos.y > groundY + 0.05) {
+        jumpVelocity.current -= GRAVITY * delta;
+        botPos.y = Math.max(groundY, botPos.y + jumpVelocity.current * delta);
+        if (botPos.y <= groundY) {
+          botPos.y = groundY;
+          jumpVelocity.current = 0;
+        }
+      }
 
       if (distance > FIRE_RANGE) {
         // Apply obstacle-avoidance steering if needed.


### PR DESCRIPTION
## Summary
- Bots now jump periodically (every 2.5–4.5s) in deathmatch mode
- Jump uses a simple velocity + gravity model: JUMP_SPEED=6, GRAVITY=18
- Bot returns to its initial Y (ground level) after each jump
- Jump timing is randomized per-bot so they don't all hop in sync
- Combined with strafe (Phase BB), bots now move in X, Y, and Z — much harder to track

## Test plan
- [x] All 879 tests pass (133 files)
- [ ] Start deathmatch — bots should visibly hop up and come back down periodically
- [ ] Bots should not get stuck airborne (gravity brings them back to groundY)
- [ ] Jump + strafe combo should feel like a real shooter opponent

🤖 Generated with [Claude Code](https://claude.com/claude-code)