### PR TITLE
Phase BG: bot shot tracer beams + fix bot-4 miss-chance config lookup

### DIFF
--- a/src/components/world/BotTracers.tsx
+++ b/src/components/world/BotTracers.tsx
@@ -1,0 +1,72 @@
+import * as React from "react";
+import * as THREE from "three";
+
+interface Tracer {
+  id: number;
+  mid: [number, number, number];
+  len: number;
+  angle: number;
+  color: string;
+}
+
+let nextId = 0;
+
+const WEAPON_COLORS: Record<string, string> = {
+  laser: "#33ffe6",
+  smg: "#ff44cc",
+  shotgun: "#ff9900",
+  rocket: "#ff2200",
+  grenade: "#66ff00",
+};
+
+/** Renders brief colored tracer beams when bots fire. Listens for the
+ *  "bot-shot-fired" CustomEvent dispatched by Bots.tsx fireBotWeapon. */
+const BotTracers: React.FC = () => {
+  const [tracers, setTracers] = React.useState<Tracer[]>([]);
+
+  React.useEffect(() => {
+    const onShot = (e: Event) => {
+      const d = (e as CustomEvent<{
+        fromX: number; fromY: number; fromZ: number;
+        toX: number; toY: number; toZ: number;
+        weaponId: string;
+      }>).detail;
+
+      const from = new THREE.Vector3(d.fromX, d.fromY, d.fromZ);
+      const to = new THREE.Vector3(d.toX, d.toY, d.toZ);
+      const dir = new THREE.Vector3().subVectors(to, from);
+      const len = dir.length();
+      if (len < 0.1) return;
+
+      const mid: [number, number, number] = [
+        (from.x + to.x) / 2,
+        (from.y + to.y) / 2,
+        (from.z + to.z) / 2,
+      ];
+      const angle = Math.atan2(dir.x, dir.z);
+      const color = WEAPON_COLORS[d.weaponId] ?? "#ffffff";
+      const id = nextId++;
+
+      setTracers(prev => [...prev.slice(-29), { id, mid, len, angle, color }]);
+      setTimeout(() => {
+        setTracers(prev => prev.filter(t => t.id !== id));
+      }, 100);
+    };
+
+    window.addEventListener("bot-shot-fired", onShot);
+    return () => window.removeEventListener("bot-shot-fired", onShot);
+  }, []);
+
+  return (
+    <>
+      {tracers.map(t => (
+        <mesh key={t.id} position={t.mid} rotation={[0, t.angle, 0]}>
+          <boxGeometry args={[0.06, 0.06, t.len]} />
+          <meshBasicMaterial color={t.color} />
+        </mesh>
+      ))}
+    </>
+  );
+};
+
+export default BotTracers;

--- a/src/pages/Solo/components/Bots.tsx
+++ b/src/pages/Solo/components/Bots.tsx
@@ -350,28 +350,46 @@ const Bots: React.FC<
         return;
       }
 
+      // Get positions early — used for tracer VFX and miss check.
+      const botPos = gameManager.getPlayers().get(botId)?.position;
+      const targetPos2 = gameManager.getPlayers().get(targetId)?.position;
+
+      // Always show a tracer beam so players can see incoming fire.
+      if (typeof window !== "undefined" && botPos && targetPos2) {
+        window.dispatchEvent(
+          new window.CustomEvent("bot-shot-fired", {
+            detail: {
+              fromX: botPos[0],
+              fromY: botPos[1] + 1.2,
+              fromZ: botPos[2],
+              toX: targetPos2[0],
+              toY: targetPos2[1] + 0.8,
+              toZ: targetPos2[2],
+              weaponId: weapon.id,
+            },
+          }),
+        );
+      }
+
       // Miss-chance check: combine base miss probability with distance factor.
-      // Determine which effective config to use based on botId.
       const botConfig =
         botId === "bot-1"
           ? effectiveBot1Config
           : botId === "bot-2"
             ? effectiveBot2Config
-            : effectiveBot3Config;
+            : botId === "bot-3"
+              ? effectiveBot3Config
+              : effectiveBot4Config;
       const baseMiss = botConfig.missChance ?? 0;
-      if (baseMiss > 0) {
-        const botPos = gameManager.getPlayers().get(botId)?.position;
-        const targetPos2 = gameManager.getPlayers().get(targetId)?.position;
-        if (botPos && targetPos2) {
-          const dist = Math.hypot(
-            botPos[0] - targetPos2[0],
-            botPos[2] - targetPos2[2],
-          );
-          // Scale up miss chance by up to 30% extra at max weapon range.
-          const distFactor = Math.min(1, dist / weapon.range) * 0.3;
-          const effectiveMiss = Math.min(1, baseMiss + distFactor);
-          if (Math.random() < effectiveMiss) return; // shot missed
-        }
+      if (baseMiss > 0 && botPos && targetPos2) {
+        const dist = Math.hypot(
+          botPos[0] - targetPos2[0],
+          botPos[2] - targetPos2[2],
+        );
+        // Scale up miss chance by up to 30% extra at max weapon range.
+        const distFactor = Math.min(1, dist / weapon.range) * 0.3;
+        const effectiveMiss = Math.min(1, baseMiss + distFactor);
+        if (Math.random() < effectiveMiss) return; // shot missed
       }
 
       const hitLanded = gameManager.hitPlayer(
@@ -387,8 +405,9 @@ const Bots: React.FC<
           // sound is best-effort only
         }
         if (typeof window !== "undefined") {
-          const targetPos = gameManager.getPlayers().get(targetId)?.position;
-          const attackerPos = gameManager.getPlayers().get(botId)?.position;
+          // Use positions already fetched for the tracer above.
+          const targetPos = targetPos2;
+          const attackerPos = botPos;
           if (targetPos) {
             window.dispatchEvent(
               new window.CustomEvent("damage-number", {

--- a/src/pages/Solo/components/SoloScene.tsx
+++ b/src/pages/Solo/components/SoloScene.tsx
@@ -8,6 +8,7 @@ import HealthPickups from "../../../components/world/HealthPickups";
 import ExplosionVFX from "../../../components/world/ExplosionVFX";
 import DamageNumbers from "../../../components/world/DamageNumbers";
 import CTFBases from "../../../components/world/CTFBases";
+import BotTracers from "../../../components/world/BotTracers";
 import type { SoloSceneProps } from "./SoloScene.types";
 
 type Props = SoloSceneProps;
@@ -127,6 +128,7 @@ export const SoloScene: React.FC<Props> = ({
       />
       <ExplosionVFX />
       <DamageNumbers />
+      <BotTracers />
       {gameState.mode === "ctf" && <CTFBases />}
     </Canvas>
   );


### PR DESCRIPTION
## Summary
- Bots now show colored tracer beams when they fire: laser=cyan, SMG=pink, shotgun=orange, rocket=red, grenade=lime
- BotTracers R3F component listens for `bot-shot-fired` CustomEvent and renders 100ms box-geometry beams in 3D space
- Tracers always show (even on misses) so players can see incoming fire and dodge
- Fixed bot-4 using bot-3's missChance config — now correctly maps bot-4 → effectiveBot4Config
- Refactored position fetches in fireBotWeapon: fetched once early, reused for tracer + miss check + hit VFX

## Test plan
- [x] All 879 tests pass (133 files)
- [ ] Start deathmatch — bots should show colored tracer lines when firing
- [ ] Verify bot-4 (laser/cyan) has its own tracer color
- [ ] Tracers should disappear after ~100ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)