### PR TITLE
Phase BH: weapon reload system — R key, ammo limits, progress bar in HUD

### DIFF
--- a/src/components/GameManager.ts
+++ b/src/components/GameManager.ts
@@ -81,6 +81,8 @@ export interface Player {
   currentKillStreak?: number;
   /** Timestamp (ms) of the most recent damage taken — used for passive health regen delay. */
   lastDamageAt?: number;
+  /** 0–1 reload progress for the currently equipped weapon; null/undefined = not reloading. */
+  reloadProgress?: number | null;
 }
 
 export class GameManager {

--- a/src/components/GameUI.tsx
+++ b/src/components/GameUI.tsx
@@ -1099,6 +1099,8 @@ const GameUI: React.FC<GameUIProps> = ({
                   const wDef = WEAPONS[currentPlayer.equippedWeaponId];
                   const ammo = currentPlayer.currentAmmo;
                   const maxAmmo = wDef?.maxAmmo;
+                  const reloadPct = currentPlayer.reloadProgress;
+                  const isReloading = reloadPct !== null && reloadPct !== undefined && reloadPct < 1;
                   const wColor =
                     currentPlayer.equippedWeaponId === "rocket"
                       ? "#ff4422"
@@ -1114,22 +1116,34 @@ const GameUI: React.FC<GameUIProps> = ({
                       <span style={{ color: wColor }}>
                         {wDef?.name ?? currentPlayer.equippedWeaponId}
                       </span>
-                      <span style={{ color: "#aaaaaa", letterSpacing: "1px" }}>
-                        {ammo === null || ammo === undefined
-                          ? "∞"
-                          : maxAmmo && maxAmmo <= 10
-                            ? Array.from({ length: maxAmmo }, (_, i) => (
-                                <span
-                                  key={i}
-                                  style={{ color: i < ammo ? wColor : "#444" }}
-                                >
-                                  ●
-                                </span>
-                              ))
-                            : `${ammo}`}
+                      {isReloading ? (
+                        <span style={{ color: "#ffcc00", letterSpacing: "1px" }}>
+                          {" RELOADING "}
+                          <span style={{ color: "#555", display: "inline-block", width: "40px", background: "#222", borderRadius: "2px", verticalAlign: "middle", height: "6px", position: "relative", overflow: "hidden" }}>
+                            <span style={{ display: "block", width: `${((reloadPct ?? 0) * 100).toFixed(0)}%`, background: "#ffcc00", height: "100%" }} />
+                          </span>
+                        </span>
+                      ) : (
+                        <span style={{ color: "#aaaaaa", letterSpacing: "1px" }}>
+                          {ammo === null || ammo === undefined
+                            ? "∞"
+                            : maxAmmo && maxAmmo <= 10
+                              ? Array.from({ length: maxAmmo }, (_, i) => (
+                                  <span
+                                    key={i}
+                                    style={{ color: i < ammo ? wColor : "#444" }}
+                                  >
+                                    ●
+                                  </span>
+                                ))
+                              : `${ammo}`}
+                        </span>
+                      )}
+                      <span style={{ color: "#555", fontSize: "10px" }}>
+                        {isReloading ? "" : " [R]=reload"}
                       </span>
                       <span style={{ color: "#555", fontSize: "10px" }}>
-                        [1/2/3]
+                        [1-5]
                       </span>
                     </>
                   );

--- a/src/components/characters/PlayerCharacter.tsx
+++ b/src/components/characters/PlayerCharacter.tsx
@@ -19,6 +19,7 @@ import {
   KEY_3,
   KEY_4,
   KEY_5,
+  KEY_R,
 } from "../utils";
 import SpacemanModel from "../SpacemanModel";
 import { getSoundManager } from "../SoundManager";
@@ -174,6 +175,7 @@ export const PlayerCharacter = React.forwardRef<
   const prevKey3Ref = React.useRef(false);
   const prevKey4Ref = React.useRef(false);
   const prevKey5Ref = React.useRef(false);
+  const prevKeyRRef = React.useRef(false);
 
   // Equip the laser blaster by default and surface the equipped weapon to the HUD.
   React.useEffect(() => {
@@ -478,12 +480,13 @@ export const PlayerCharacter = React.forwardRef<
     const key3 = keysPressedRef.current[KEY_3] ?? false;
     const key4 = keysPressedRef.current[KEY_4] ?? false;
     const key5 = keysPressedRef.current[KEY_5] ?? false;
+    const keyR = keysPressedRef.current[KEY_R] ?? false;
     const myId = socketClient?.id || currentPlayerId;
     if (key1 && !prevKey1Ref.current) {
       weaponManagerRef.current.equip("laser");
       gameManager?.updatePlayer(myId, {
         equippedWeaponId: "laser",
-        currentAmmo: null,
+        currentAmmo: weaponManagerRef.current.getAmmo("laser"),
       });
     }
     if (key2 && !prevKey2Ref.current) {
@@ -514,11 +517,19 @@ export const PlayerCharacter = React.forwardRef<
         currentAmmo: weaponManagerRef.current.getAmmo("smg"),
       });
     }
+    // R key: reload the current weapon (rising-edge).
+    if (keyR && !prevKeyRRef.current) {
+      const equipped = weaponManagerRef.current.getEquipped();
+      if (equipped) {
+        weaponManagerRef.current.startReload(equipped.id);
+      }
+    }
     prevKey1Ref.current = key1;
     prevKey2Ref.current = key2;
     prevKey3Ref.current = key3;
     prevKey4Ref.current = key4;
     prevKey5Ref.current = key5;
+    prevKeyRRef.current = keyR;
 
     // Fire the equipped weapon while left-click is held (rate-limited by
     // WeaponManager's per-shooter cooldown).
@@ -585,9 +596,10 @@ export const PlayerCharacter = React.forwardRef<
             beamColor,
           );
         }
-        // Sync ammo to HUD after each shot.
+        // Sync ammo + reload progress to HUD after each shot.
         const remainingAmmo = weaponManagerRef.current.getAmmo(wid);
-        gameManager?.updatePlayer(myId, { currentAmmo: remainingAmmo });
+        const reloadProgress = weaponManagerRef.current.getReloadProgress(wid);
+        gameManager?.updatePlayer(myId, { currentAmmo: remainingAmmo, reloadProgress });
       }
       if (fireResult && fireResult.hit && typeof window !== "undefined") {
         // Notify HUD to flash hit marker.
@@ -962,6 +974,17 @@ export const PlayerCharacter = React.forwardRef<
     }
 
     // Notify parent of position changes (only when position actually changes)
+    // Continuously sync reload progress so HUD bar updates smoothly.
+    {
+      const equipped = weaponManagerRef.current.getEquipped();
+      if (equipped) {
+        const rp = weaponManagerRef.current.getReloadProgress(equipped.id);
+        const ammo = weaponManagerRef.current.getAmmo(equipped.id);
+        const myId2 = socketClient?.id || currentPlayerId;
+        gameManager?.updatePlayer(myId2, { currentAmmo: ammo, reloadProgress: rp });
+      }
+    }
+
     if (onPositionUpdate && meshRef.current) {
       const currentPos = meshRef.current.position;
       const distanceMoved = currentPos.distanceTo(

--- a/src/components/combat/WeaponManager.ts
+++ b/src/components/combat/WeaponManager.ts
@@ -7,6 +7,10 @@ export interface WeaponConfig {
   cooldownMs: number;
   /** Maximum ammo capacity. undefined/null means infinite. */
   maxAmmo?: number;
+  /** Reload duration in ms. undefined = instant refill. */
+  reloadTimeMs?: number;
+  /** If true, weapon reloads automatically when ammo hits 0. */
+  autoReload?: boolean;
   /** Area-of-effect radius (world units). Nearby entities within this range of the impact point take splashDamage. */
   splashRadius?: number;
   /** Damage dealt to entities caught in the splash radius (not the direct-hit target). */
@@ -20,6 +24,9 @@ export const WEAPONS: Record<string, WeaponConfig> = {
     damage: 10,
     range: 30,
     cooldownMs: 500,
+    maxAmmo: 10,
+    reloadTimeMs: 1800,
+    autoReload: true,
   },
   shotgun: {
     id: "shotgun",
@@ -28,6 +35,7 @@ export const WEAPONS: Record<string, WeaponConfig> = {
     range: 8,
     cooldownMs: 1000,
     maxAmmo: 6,
+    reloadTimeMs: 2200,
   },
   rocket: {
     id: "rocket",
@@ -36,6 +44,7 @@ export const WEAPONS: Record<string, WeaponConfig> = {
     range: 12,
     cooldownMs: 2000,
     maxAmmo: 3,
+    reloadTimeMs: 3000,
     splashRadius: 5,
     splashDamage: 50,
   },
@@ -45,7 +54,7 @@ export const WEAPONS: Record<string, WeaponConfig> = {
     damage: 100,
     range: 18,
     cooldownMs: 4000,
-    maxAmmo: 2,
+    maxAmmo: 3,
     splashRadius: 7,
     splashDamage: 75,
   },
@@ -56,6 +65,7 @@ export const WEAPONS: Record<string, WeaponConfig> = {
     range: 18,
     cooldownMs: 120,
     maxAmmo: 40,
+    reloadTimeMs: 2000,
   },
 };
 
@@ -67,6 +77,7 @@ export class WeaponManager {
   private equippedWeaponId: string | null = null;
   private lastFiredAt: Map<string, number> = new Map();
   private ammoMap: Map<string, number> = new Map();
+  private reloadStartAt: Map<string, number> = new Map();
 
   equip(weaponId: string): boolean {
     const weapon = WEAPONS[weaponId];
@@ -84,6 +95,40 @@ export class WeaponManager {
     const weapon = WEAPONS[weaponId];
     if (weapon?.maxAmmo !== undefined) {
       this.ammoMap.set(weaponId, weapon.maxAmmo);
+      this.reloadStartAt.delete(weaponId);
+    }
+  }
+
+  /** Begin reloading the weapon. No-op if already reloading or at full ammo. */
+  startReload(weaponId: string, now: number = Date.now()): boolean {
+    const weapon = WEAPONS[weaponId];
+    if (!weapon?.reloadTimeMs) return false;
+    if (this.reloadStartAt.has(weaponId)) return false; // already reloading
+    const current = this.ammoMap.get(weaponId) ?? (weapon.maxAmmo ?? 0);
+    if (current >= (weapon.maxAmmo ?? 0)) return false; // already full
+    this.reloadStartAt.set(weaponId, now);
+    return true;
+  }
+
+  /** Returns 0–1 reload progress, or null if not reloading. 1 = complete. */
+  getReloadProgress(weaponId: string, now: number = Date.now()): number | null {
+    const weapon = WEAPONS[weaponId];
+    if (!weapon?.reloadTimeMs) return null;
+    const start = this.reloadStartAt.get(weaponId);
+    if (start === undefined) return null;
+    return Math.min(1, (now - start) / weapon.reloadTimeMs);
+  }
+
+  isReloading(weaponId: string, now: number = Date.now()): boolean {
+    const progress = this.getReloadProgress(weaponId, now);
+    return progress !== null && progress < 1;
+  }
+
+  /** Completes a finished reload, refilling ammo. Called from canFire/fire checks. */
+  private completeReloadIfDone(weaponId: string, now: number): void {
+    const progress = this.getReloadProgress(weaponId, now);
+    if (progress !== null && progress >= 1) {
+      this.refill(weaponId);
     }
   }
 
@@ -106,10 +151,16 @@ export class WeaponManager {
     const weapon = this.getEquipped();
     if (!weapon) return false;
 
+    // Complete a finished reload before checking ammo.
+    this.completeReloadIfDone(weapon.id, now);
+
+    // Block firing while reloading.
+    if (this.isReloading(weapon.id, now)) return false;
+
     const last = this.lastFiredAt.get(shooterId);
     if (last !== undefined && now - last < weapon.cooldownMs) return false;
 
-    // Ammo check
+    // Ammo check.
     if (weapon.maxAmmo !== undefined) {
       const ammo = this.ammoMap.get(weapon.id) ?? weapon.maxAmmo;
       if (ammo <= 0) return false;
@@ -132,7 +183,12 @@ export class WeaponManager {
 
     if (weapon.maxAmmo !== undefined) {
       const current = this.ammoMap.get(weapon.id) ?? weapon.maxAmmo;
-      this.ammoMap.set(weapon.id, Math.max(0, current - 1));
+      const next = Math.max(0, current - 1);
+      this.ammoMap.set(weapon.id, next);
+      // Auto-reload weapons start reloading immediately when emptied.
+      if (next === 0 && weapon.autoReload) {
+        this.startReload(weapon.id, now);
+      }
     }
 
     return weapon;

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -11,6 +11,7 @@ export const KEY_2 = "2";
 export const KEY_3 = "3";
 export const KEY_4 = "4";
 export const KEY_5 = "5";
+export const KEY_R = "r";
 export const DIRECTIONS = [W, A, S, D, Q, E];
 
 export class KeyDisplay {


### PR DESCRIPTION
## Summary
- Laser now has 10 shots + auto-reload in 1.8s (always available, never permanently empty)
- Grenade updated from 2→3 shots (no reload per user request — hold-to-toss arc is a future phase)
- R key triggers manual reload for any weapon with `reloadTimeMs` defined
- WeaponManager: new `startReload`, `isReloading`, `getReloadProgress`, `completeReloadIfDone` methods
- GameUI: ammo display shows yellow "RELOADING ▓▓▓" progress bar while reloading
- Reload progress synced to HUD every frame via `player.reloadProgress` field
- SMG: 40→reload in 2s, Shotgun: 6→reload in 2.2s, Rocket: 3→reload in 3s

## Test plan
- [x] All 879 tests pass (133 files)
- [ ] Fire laser 10 times — auto-reload starts, HUD shows RELOADING bar
- [ ] Press R mid-magazine on shotgun — reload starts early
- [ ] Switch away and back to laser — ammo count preserved
- [ ] Laser always comes back after reload (never permanently empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)