### PR TITLE
Phase BI: bot LOS wall check — bots can't shoot through obstacles

### DIFF
--- a/src/components/CollisionSystem.ts
+++ b/src/components/CollisionSystem.ts
@@ -292,6 +292,27 @@ export class CollisionSystem {
     return closest;
   }
 
+  /**
+   * Returns true if there is a clear line-of-sight from `from` to `to`
+   * (i.e. no boundary box intersects the segment). Used by bot AI to skip
+   * firing when a wall is in the way.
+   */
+  hasLineOfSight(from: THREE.Vector3, to: THREE.Vector3): boolean {
+    const dir = new THREE.Vector3().subVectors(to, from);
+    const dist = dir.length();
+    if (dist < 0.01) return true;
+    dir.divideScalar(dist);
+    const ray = new THREE.Ray(from, dir);
+    for (const box of this.boundaries) {
+      const hit = ray.intersectBox(box, new THREE.Vector3());
+      if (hit !== null) {
+        const hitDist = hit.distanceTo(from);
+        if (hitDist > 0.1 && hitDist < dist - 0.3) return false;
+      }
+    }
+    return true;
+  }
+
   // Get boundary geometry for rendering (optional, for debugging)
   getBoundaryGeometry(): THREE.BufferGeometry[] {
     return this.boundaries.map((boundary) => {

--- a/src/pages/Solo/components/Bots.tsx
+++ b/src/pages/Solo/components/Bots.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useRef } from "react";
+import * as THREE from "three";
 import { BotCharacter } from "../../../components/characters/BotCharacter";
 import type { SoloSceneProps } from "./SoloScene.types";
 import type { BotConfig as FullBotConfig } from "../../../components/characters/useBotAI";
@@ -369,6 +370,17 @@ const Bots: React.FC<
             },
           }),
         );
+      }
+
+      // LOS wall check: skip damage if an obstacle blocks the shot.
+      if (botPos && targetPos2 && collisionSystemRef.current) {
+        const from = new THREE.Vector3(
+          botPos[0], botPos[1] + 1.2, botPos[2],
+        );
+        const to = new THREE.Vector3(
+          targetPos2[0], targetPos2[1] + 0.8, targetPos2[2],
+        );
+        if (!collisionSystemRef.current.hasLineOfSight(from, to)) return;
       }
 
       // Miss-chance check: combine base miss probability with distance factor.


### PR DESCRIPTION
## Summary
- Added `hasLineOfSight(from, to)` method to `CollisionSystem` using `THREE.Ray.intersectBox` against all boundary boxes
- Bots now skip dealing damage when a wall/rock/crate blocks their shot line
- Tracer beam still renders (shows the shot hitting the wall) — only the hit event is suppressed
- THREE.js import added to Bots.tsx

## Test plan
- [x] All 879 tests pass (133 files)
- [ ] Hide behind a crate — bots stop damaging player while obscured
- [ ] Move into the open — damage resumes immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)