### PR TITLE
Phase BK: smooth player movement — velocity-based acceleration/deceleration

### DIFF
--- a/src/components/characters/PlayerCharacter.tsx
+++ b/src/components/characters/PlayerCharacter.tsx
@@ -137,6 +137,7 @@ export const PlayerCharacter = React.forwardRef<
   const {
     velocityRef,
     directionRef,
+    currentSpeedRef,
     inputDirectionRef,
     finalMovementRef,
     isJumpingRef,
@@ -197,6 +198,7 @@ export const PlayerCharacter = React.forwardRef<
       cameraRotationRef.current = { horizontal: 0, vertical: 0.2 };
       velocityRef.current.set(0, 0, 0);
       directionRef.current.set(0, 0, 0);
+      currentSpeedRef.current = 0;
       isJumpingRef.current = false;
       verticalVelocityRef.current = 0;
     },
@@ -656,9 +658,15 @@ export const PlayerCharacter = React.forwardRef<
 
       if (dir && dir.length() > 0) {
         directionRef.current.copy(dir);
+        // Smoothly accelerate toward target speed (10× per second ramp-up).
+        currentSpeedRef.current = THREE.MathUtils.lerp(
+          currentSpeedRef.current,
+          speed,
+          Math.min(1, 10 * delta),
+        );
         velocityRef.current
           .copy(directionRef.current)
-          .multiplyScalar(speed * delta);
+          .multiplyScalar(currentSpeedRef.current * delta);
 
         // Calculate new position with collision detection
         const currentPosition = meshRef.current.position.clone();
@@ -754,6 +762,13 @@ export const PlayerCharacter = React.forwardRef<
           });
         }
       }
+    } else {
+      // No movement input — smoothly decelerate to zero (15× per second ramp-down).
+      currentSpeedRef.current = THREE.MathUtils.lerp(
+        currentSpeedRef.current,
+        0,
+        Math.min(1, 15 * delta),
+      );
     }
 
     // Jump mechanics - Single jump only, no jetpack from jump

--- a/src/lib/hooks/usePlayerPhysics.ts
+++ b/src/lib/hooks/usePlayerPhysics.ts
@@ -47,6 +47,9 @@ export function usePlayerPhysics() {
   } | null>(null);
   const lastRCSSoundTimeRef = useRef(0); // Throttle RCS sound
 
+  // Smoothed speed scalar (world units/s, lerped toward target each frame)
+  const currentSpeedRef = useRef(0);
+
   // Reusable vectors to avoid allocations in animation loop
   const inputDirectionRef = useRef(new THREE.Vector3());
   const finalMovementRef = useRef(new THREE.Vector3());
@@ -55,6 +58,7 @@ export function usePlayerPhysics() {
     // Core movement refs
     velocityRef,
     directionRef,
+    currentSpeedRef,
     inputDirectionRef,
     finalMovementRef,
 


### PR DESCRIPTION
## Summary
- Added `currentSpeedRef` to `usePlayerPhysics` to track smoothed horizontal speed
- On movement input: speed lerps toward target at 10×/s (smooth acceleration, ~0.3s to full speed)
- On no input: speed lerps toward 0 at 15×/s (crisp deceleration, ~0.2s to stop)
- Speed resets instantly when player freezes/respawns
- No change to jump, jetpack, or collision logic

## Test plan
- [x] All 879 tests pass (133 files)
- [ ] Player ramps up smoothly on WASD press, glides briefly then stops on release
- [ ] Sprint transition also smooths (shift down/up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)