### PR TITLE
docs(pmo): weekly doc update 2026-06-25

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -4,7 +4,6 @@ Status guide: `[shipped]` is live today, `[in-progress]` is partially implemente
 
 ## Game Modes
 
-
 ### 🤖 Solo Mode with AI Bots `[shipped/live]`
 
 - **Bot AI**: Intelligent bots with pathfinding and tagging behavior
@@ -66,6 +65,52 @@ Status guide: `[shipped]` is live today, `[in-progress]` is partially implemente
 
 - **Sound Effects**: Tag sounds, jump sounds, ambient audio
 - **Music**: Background music with volume controls
+
+## Combat & Gameplay
+
+### 🔫 Shooting Gallery Mode `[shipped]`
+
+- **Phase BM**: standalone target-practice mode with dedicated crosshair overlay and improved bot tracer rendering
+
+### 🎯 Player Reticle & Mouse-Aimed Firing `[shipped]`
+
+- **Phase BL**: ground-plane raycast maps mouse position to a world-space aim target; CSS crosshair follows cursor; all player shots fire toward the aimed point
+
+### 🏃 Smooth Velocity-Based Player Movement `[shipped]`
+
+- **Phase BK**: velocity scalar lerp (10×/s acceleration, 15×/s deceleration) replaces instant movement; gives movement weight and responsiveness
+
+### 🌀 Bot Angular Spread / Miss Physics `[shipped]`
+
+- **Phase BJ**: 2D rotation-matrix deviation applied to bot shots so misses fly to a visible off-target point rather than vanishing silently
+
+### 👁️ Bot Line-of-Sight Wall Checks `[shipped]`
+
+- **Phase BI**: `CollisionSystem.hasLineOfSight` raycast prevents bots from firing through obstacles; bots wait until a clear sight-line exists
+
+### 🔁 Weapon Reload System `[shipped]`
+
+- **Phase BH**: per-weapon ammo limits; laser auto-reloads, all weapons support R-key manual reload; reload progress bar rendered in HUD via `WeaponManager.startReload/isReloading/getReloadProgress`
+
+### ✨ Bot Shot Tracer Beams `[shipped]`
+
+- **Phase BG**: visual streak rendered for every bot projectile, giving players clear feedback on incoming fire direction
+
+### ⚠️ Score Tension Warning `[shipped]`
+
+- **Phase BF**: pulsing alert triggers when the score leader is 1–2 kills from winning, raising match tension in the final moments
+
+### 🦘 Bot Jumping in Deathmatch `[shipped]`
+
+- **Phase BE**: bots execute jumps during combat, making them harder to track and improving AI believability
+
+### 🔴 Hit Direction Indicator `[shipped]`
+
+- **Phase BD**: red arrow rendered at the screen edge in the direction of incoming damage, giving the player spatial awareness of attackers
+
+### 🔄 Auto-Restart After Results Screen `[shipped]`
+
+- **Phase BC**: combat modes (Deathmatch, CTF) automatically restart after a 7-second results screen, keeping sessions flowing without manual input
 
 ## Technical Features
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/nitsuah/darkmoon/actions/workflows/ci.yml/badge.svg)](https://github.com/nitsuah/darkmoon/actions)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/2ae05c81-761a-4d3a-91ac-dcd5980d48d3/deploy-status)](https://app.netlify.com/projects/darkmoon-dev/deploys)
 
-> Solo-live 3D browser tag game built with React 19, Three Fiber, Socket.io, and Vite. **Solo mode is the live experience; multiplayer is planned.**
+> 3D browser combat game built with React 19, Three Fiber, Socket.io, and Vite. **Solo mode with full combat gameplay is live; multiplayer is planned.**
 
 **Live Demo:** [darkmoon.dev](https://darkmoon.dev)
 
@@ -14,9 +14,12 @@
 
 ## ✨ Features
 
-- `[shipped]` **Solo Mode with AI Bots** — Practice against intelligent bot opponents on the live site.
-- `[in-progress]` **Multiplayer 3D Gameplay** — Multiplayer foundations exist, but the deployed experience is still solo-first.
+- `[shipped]` **Combat Gameplay with AI Bots** — Full deathmatch and CTF modes with bot LOS checks, weapon reload system, angular spread, bot jumping, tracer beams, hit direction indicators, and score tension alerts.
+- `[shipped]` **Shooting Gallery Mode** — Standalone target-practice mode (Phase BM) with crosshair and bot tracer improvements.
+- `[shipped]` **Mouse-Aimed Firing & Player Reticle** — Ground-plane raycast aiming with CSS crosshair overlay; velocity-based smooth movement.
+- `[shipped]` **Pluggable Game Mode Architecture** — `GameModeHandler` interface decouples mode logic; `TagMode`, `DeathmatchMode`, and `CTFMode` ship as reference implementations.
 - `[shipped]` **WebSocket Server Foundation** — Socket.io and server validation are in place for future live modes.
+- `[in-progress]` **Multiplayer 3D Gameplay** — Multiplayer foundations exist, but the deployed experience is still solo-first.
 - `[in-progress]` **Mobile Support** — Responsive layout and touch controls exist, but device validation is still open.
 - `[shipped]` **Modern Tooling** — Vite, Vitest, ESLint, Prettier, TypeScript, and CI are wired into the repo.
 
@@ -34,7 +37,7 @@ Visit `http://localhost:4444`. **Solo mode is the only live experience; multipla
 All checks run via Docker — no local Node.js required.
 
 ```bash
-# Run all tests (366 tests, Vitest)
+# Run all tests (378+ tests, Vitest)
 docker compose -f config/docker-compose.yml --project-name darkmoon --profile test run --rm test
 
 # Lint

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,10 +1,14 @@
 # Roadmap
 
-Last Updated: 2026-06-08
+Last Updated: 2026-06-25
 
 ## 2025 Q4 ✅
 
 > Completed. Browser-game foundation and baseline gameplay infrastructure shipped.
+
+## Beyond Original Scope — Combat Gameplay (Phases BC–BM) ✅
+
+> Significant combat gameplay shipped beyond the original roadmap scope. Phases BC–BM delivered: auto-restart after results screen, hit direction indicator, bot jumping in deathmatch, score tension warning, bot tracer beams, weapon reload system (R key, ammo limits, HUD bar), bot LOS wall checks, bot angular spread/miss physics, smooth velocity-based player movement, mouse-aimed firing with player reticle, and shooting gallery mode with crosshair improvements. Deathmatch (Phase C) and CTF (Phase D) modes also shipped.
 
 ## 2026 Q1 (In Progress)
 
@@ -15,11 +19,13 @@ Last Updated: 2026-06-08
 ## 2026 Q2 (Planned)
 
 ### CEO Priorities
+
 - [ ] **21st.dev components integration**: leverage 21st.dev component library to enhance the look, feel, and interactivity of the game site — replace or augment existing UI surfaces with higher-quality, more interactive components.
 - [ ] **UI/UX polish pass using 21st.dev**: apply improved card layouts, transitions, and interactive states to the game lobby, scoreboard, and game-over screens.
 - [ ] **Open-source safety scrub**: remove or anonymize any sensitive, proprietary, or employer-identifying content so the repo can be shared publicly without exposing confidential details.
 
 ### Existing Planned Items
+
 - [ ] Define the multiplayer readiness gate around deployment, CORS, logging, shutdown behavior, and operational visibility.
 - [ ] Add `ARCHITECTURE.md`, `API.md`, and a measured `METRICS.md` refresh.
 - [ ] Re-scope the remaining refactor backlog against the current codebase.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,6 @@
 # Tasks
 
-Last Updated: 2026-06-11
+Last Updated: 2026-06-25
 
 ## In Progress
 
@@ -31,6 +31,25 @@ Last Updated: 2026-06-11
     anyone from re-tagging a just-tagged player), both reset cleanly on
     `startTagGame`/`endGame`. Verified for player and bot — full Docker suite is 378
     passed / 5 skipped, lint (`--max-warnings=0`) and `tsc --noEmit` both clean.
+
+- [x] **[Phase A] Pluggable game modes** — extract tag logic out of `GameManager` behind a `GameModeHandler` interface (`onStart`/`onTick`/`onAction`/`onPlayerRemoved`/`onEnd`), with a `TagMode` implementation preserving current behavior.
+  - Done: `src/components/gameModes/{GameModeHandler,TagMode}.ts`; `GameManager` is now a thin host delegating to the active mode. Existing `gameManager.*.test.ts` and `Bots.test.tsx` pass unchanged.
+
+- [x] **[Phase B] Combat primitives** — `WeaponManager`, projectile/hit-detection, `health`/`respawn` on `Player`, full vertical slice in Solo mode.
+  - Done: all primitives plus full combat-feel polish (Phases BG–BM):
+    - BG: bot shot tracer effects (visual streaks for every bot shot)
+    - BH: per-weapon ammo + reload system (laser auto-reload, R-key manual reload, reload bar HUD, `WeaponManager.startReload/isReloading/getReloadProgress`)
+    - BI: bot LOS wall check (`CollisionSystem.hasLineOfSight`, bots can't fire through obstacles)
+    - BJ: bot angular spread (2D rotation-matrix deviation so misses fly to a visible off-target point)
+    - BK: smooth player movement (velocity scalar lerp — 10×/s accel, 15×/s decel)
+    - BL: player reticle + mouse-aimed firing (ground-plane raycast, CSS crosshair) — PR #321
+    - BM: shooting gallery mode + crosshair + bot tracer improvements
+
+- [x] **[Phase C] Deathmatch mode** — kill tracking, respawn, and scoreboard via `GameUI`.
+  - Done: `DeathmatchMode`, kill-limit win condition, respawn timer, bot combat AI, health/kill HUD; see `docs/MULTIPLAYER_SHOOTER_ROADMAP.md` Phase C.
+
+- [x] **[Phase D] Capture the Flag mode** — teams, flag entities, and capture zones.
+  - Done: `CTFMode`, team assignment, flag pickup/carry/capture/drop-on-death, bot CTF AI, CTF combat, team HUD; see `docs/MULTIPLAYER_SHOOTER_ROADMAP.md` Phase D.
 
 ## Todo
 
@@ -84,28 +103,10 @@ Last Updated: 2026-06-11
   - Problem: older refactor tasks no longer match the codebase hotspots.
   - Acceptance Criteria: only current, high-value refactors remain and each one ties back to reliability, testability, or performance.
 
-- [x] **[Phase A] Pluggable game modes** — extract tag logic out of `GameManager` behind a `GameModeHandler` interface (`onStart`/`onTick`/`onAction`/`onPlayerRemoved`/`onEnd`), with a `TagMode` implementation preserving current behavior.
-  - Done: `src/components/gameModes/{GameModeHandler,TagMode}.ts`; `GameManager` is now a thin host delegating to the active mode. Existing `gameManager.*.test.ts` and `Bots.test.tsx` pass unchanged.
-
-- [x] **[Phase B] Combat primitives** — `WeaponManager`, projectile/hit-detection, `health`/`respawn` on `Player`, full vertical slice in Solo mode.
-  - Done: all primitives plus full combat-feel polish (Phases BG–BL):
-    - BG: bot shot tracer effects (visual streaks for every bot shot)
-    - BH: per-weapon ammo + reload system (laser auto-reload, R-key manual reload, reload bar HUD, `WeaponManager.startReload/isReloading/getReloadProgress`)
-    - BI: bot LOS wall check (`CollisionSystem.hasLineOfSight`, bots can't fire through obstacles)
-    - BJ: bot angular spread (2D rotation-matrix deviation so misses fly to a visible off-target point)
-    - BK: smooth player movement (velocity scalar lerp — 10×/s accel, 15×/s decel)
-    - BL: player reticle + mouse-aimed firing (ground-plane raycast, CSS crosshair) — PR #321
-
 - [ ] **[Phase BM] Grenade hold-to-throw + trajectory arc** — hold LMB to charge, release to throw; dotted arc previews the parabolic landing zone.
   - Priority: P2
   - Problem: grenade currently fires like a laser (instant, straight-line). Intended mechanic is hold-to-charge + release with a live arc preview.
   - Acceptance Criteria: holding LMB with grenade equipped renders a dotted parabolic arc from player to predicted landing zone; releasing fires along that arc; throw distance scales with hold duration; existing grenade damage/splash radius unchanged.
-
-- [x] **[Phase C] Deathmatch mode** — kill tracking, respawn, and scoreboard via `GameUI`.
-  - Done: `DeathmatchMode`, kill-limit win condition, respawn timer, bot combat AI, health/kill HUD; see `docs/MULTIPLAYER_SHOOTER_ROADMAP.md` Phase C.
-
-- [x] **[Phase D] Capture the Flag mode** — teams, flag entities, and capture zones.
-  - Done: `CTFMode`, team assignment, flag pickup/carry/capture/drop-on-death, bot CTF AI, CTF combat, team HUD; see `docs/MULTIPLAYER_SHOOTER_ROADMAP.md` Phase D.
 
 - [ ] **[Phase E] Multiplayer shooter polish** — over-the-shoulder aim camera and combat music cross-fade layer.
   - Priority: P2


### PR DESCRIPTION
## Summary

Weekly PMO doc sync for darkmoon.

### Changes
- FEATURES.md: added Combat & Gameplay section covering phases BC-BM (shooting gallery, weapon reload, bot LOS, hit direction indicators, velocity movement, bot tracer beams, score tension warning, auto-restart, bot jumping, bot angular spread, player reticle)
- README.md: updated feature highlights to reflect combat mode evolution beyond basic tag; updated test count to 378+
- TASKS.md: moved completed Phase A, B, C, D items from Todo to Done; updated Last Updated to 2026-06-25
- ROADMAP.md: added note that phases BC-BM shipped beyond original scope; updated Last Updated to 2026-06-25

🤖 Generated with [Claude Code](https://claude.com/claude-code)