### PR TITLE
fix(deps): patch ip-address and socket.io-parser security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1187,9 +1187,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1207,9 +1204,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1227,9 +1221,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1247,9 +1238,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1267,9 +1255,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1287,9 +1272,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4497,7 +4479,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -5339,9 +5323,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5363,9 +5344,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5387,9 +5365,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5411,9 +5386,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6966,7 +6938,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.6",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "overrides": {
     "three": "^0.180.0",
     "flatted": "^3.4.2",
-    "socket.io-parser": "^4.2.6",
+    "socket.io-parser": "^4.2.7",
+    "ip-address": "^10.4.0",
     "ajv": "^6.14.0",
     "@babel/core": ">=7.29.6",
     "react-router": "^7.18.2"


### PR DESCRIPTION
## Summary
- Bumps ip-address override to ^10.4.0 (was ^10.2.0) to patch three CVEs: leading-zero octal SSRF bypass (GHSA-mwp4-54f8-5fhr), IPv4-mapped/NAT64 misclassification (GHSA-22jq-vg5j-6vgg), and CIDR suffix trust-boundary bypass (GHSA-4xrf-jv44-h6hh)
- Bumps socket.io-parser override to ^4.2.7 (was ^4.2.6) to patch zero-attachment memory exhaustion (GHSA-2m8v-j782-fhvr)
- Regenerates package-lock.json with patched resolved versions

Closes Dependabot alerts #166, #167, #168, #169.

## Test plan
- [ ] npm audit no longer reports ip-address or socket.io-parser vulnerabilities
- [ ] CI passes (typecheck, lint, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal package versions to incorporate maintenance and security improvements.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->