### PR TITLE
feat(server): add multiplayer readiness gate (deployment, CORS, logging, observability)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,31 @@
+# ---------------------------------------------------------------------------
+# Client (Vite)
+# ---------------------------------------------------------------------------
+
 # Development WebSocket server URL
 VITE_SOCKET_SERVER_URL=http://localhost:4444
 
 # Production WebSocket server URL (set in Netlify environment variables)
 # VITE_SOCKET_SERVER_URL=https://your-production-websocket-server.com
+
+# ---------------------------------------------------------------------------
+# Server (see docs/MULTIPLAYER_GATE.md)
+# ---------------------------------------------------------------------------
+
+# Port the Express + Socket.io server binds to.
+PORT=4444
+
+# Comma-separated CORS allow-list applied to BOTH the HTTP app and the Socket.io
+# handshake. A `*` acts as a wildcard within an entry (used for Netlify deploy
+# previews); every other character is matched literally. When unset, the server
+# falls back to its localhost + darkmoon-dev.netlify.app defaults.
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:4444,https://darkmoon-dev.netlify.app,https://deploy-preview-*--darkmoon-dev.netlify.app
+
+# Structured log threshold: debug | info | warn | error | silent (default: info).
+LOG_LEVEL=info
+
+# Optional build identifier surfaced in the /health payload.
+# APP_VERSION=1.0.0
+
+# Optional comma-separated profanity list overriding the server default.
+# CHAT_PROFANITY=word1,word2

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,9 +94,10 @@ USER appuser
 # Expose the application port
 EXPOSE 4444
 
-# Health check endpoint
+# Health check endpoint. Hits /health (not /) and asserts the reported status so
+# a server that answers but cannot describe its own state is treated as failing.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:4444/', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)}).on('error', () => process.exit(1))"
+  CMD node -e "require('http').get('http://localhost:4444/health', (r) => {let d='';r.on('data',c=>d+=c);r.on('end',()=>{try{const s=JSON.parse(d).status;process.exit(r.statusCode===200&&(s==='ok'||s==='degraded')?0:1)}catch{process.exit(1)}})}).on('error', () => process.exit(1))"
 
 # Start the Express server directly with Node
 CMD ["node", "server/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ EXPOSE 4444
 # Health check endpoint. Hits /health (not /) and asserts the reported status so
 # a server that answers but cannot describe its own state is treated as failing.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:4444/health', (r) => {let d='';r.on('data',c=>d+=c);r.on('end',()=>{try{const s=JSON.parse(d).status;process.exit(r.statusCode===200&&(s==='ok'||s==='degraded')?0:1)}catch{process.exit(1)}})}).on('error', () => process.exit(1))"
+  CMD node -e "require('http').get('http://localhost:'+(process.env.PORT||4444)+'/health', (r) => {let d='';r.on('data',c=>d+=c);r.on('end',()=>{try{const s=JSON.parse(d).status;process.exit(r.statusCode===200&&(s==='ok'||s==='degraded')?0:1)}catch{process.exit(1)}})}).on('error', () => process.exit(1))"
 
 # Start the Express server directly with Node
 CMD ["node", "server/index.js"]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ Last Updated: 2026-08-22
 
 ### Existing Planned Items
 
-- [ ] Define the multiplayer readiness gate around deployment, CORS, logging, shutdown behavior, and operational visibility.
+- [x] Define the multiplayer readiness gate around deployment, CORS, logging, shutdown behavior, and operational visibility. _(completed 2026-08-27; see `docs/MULTIPLAYER_GATE.md` — all four criteria pass)_
 - [x] Add `ARCHITECTURE.md` and `API.md`. _(completed 2026-08-21; `docs/ARCHITECTURE.md` and `docs/API.md` exist)_
 - [ ] Measured `METRICS.md` refresh. _(estimates remain; in-progress)_
 - [ ] Re-scope the remaining refactor backlog against the current codebase.

--- a/TASKS.md
+++ b/TASKS.md
@@ -102,10 +102,22 @@ Last Updated: 2026-08-21
   - Problem: current metrics are still estimate-heavy.
   - Acceptance Criteria: build, test, and coverage values are measured or clearly marked `TBD` with blockers.
 
-- [ ] Finish server production-hardening work beyond the current baseline.
+- [x] Finish server production-hardening work beyond the current baseline.
   - Priority: P1
-  - Problem: structured logging, graceful shutdown, and operational visibility have not been fully verified.
-  - Acceptance Criteria: hardening tasks are documented, implemented, and validated.
+  - Completed: 2026-08-27
+  - Evidence: `docs/MULTIPLAYER_GATE.md` defines the four readiness criteria
+    (deployment, CORS, logging, observability) each with a runnable acceptance
+    check, and the repo passes all four. New modules `server/logger.js`
+    (structured JSON logging + game event catalogue), `server/cors.js` (shared
+    HTTP/WebSocket allow-list), and `server/health.js` (`/health` payload), plus
+    SIGTERM graceful shutdown in `server/index.js`. Covered by 69 new tests in
+    `src/__tests__/server.{logger,cors,health}.test.ts`. Full suite: 77 files,
+    627 passed / 5 skipped; typecheck and lint clean.
+  - Note: fixed two latent bugs found while validating — the SPA fallback was
+    mounted before the API router (so `/health` returned `index.html` for any
+    `Accept: */*` request, including the Docker healthcheck and Render probe),
+    and the CORS wildcard matcher did not escape regex metacharacters (so
+    `darkmoon-dev.netlify.app` also matched look-alike hosts).
 
 - [ ] Re-baseline the remaining large-file refactor work.
   - Priority: P2

--- a/TASKS.md
+++ b/TASKS.md
@@ -109,15 +109,25 @@ Last Updated: 2026-08-21
     (deployment, CORS, logging, observability) each with a runnable acceptance
     check, and the repo passes all four. New modules `server/logger.js`
     (structured JSON logging + game event catalogue), `server/cors.js` (shared
-    HTTP/WebSocket allow-list), and `server/health.js` (`/health` payload), plus
-    SIGTERM graceful shutdown in `server/index.js`. Covered by 69 new tests in
-    `src/__tests__/server.{logger,cors,health}.test.ts`. Full suite: 77 files,
-    627 passed / 5 skipped; typecheck and lint clean.
-  - Note: fixed two latent bugs found while validating — the SPA fallback was
-    mounted before the API router (so `/health` returned `index.html` for any
-    `Accept: */*` request, including the Docker healthcheck and Render probe),
-    and the CORS wildcard matcher did not escape regex metacharacters (so
-    `darkmoon-dev.netlify.app` also matched look-alike hosts).
+    HTTP/WebSocket allow-list), `server/health.js` (`/health` payload),
+    `server/port.js` (`PORT` validation), and `server/tagAuthorization.js`
+    (pure `player-tagged` authorization decision — impersonation/self-tag/
+    unknown-player rejection), plus SIGTERM graceful shutdown in
+    `server/index.js`. Covered by 95 new tests across
+    `src/__tests__/server.{logger,cors,health,port,tagAuthorization}.test.ts`.
+    Full suite: 79 files, 653 passed / 5 skipped; typecheck and lint clean.
+  - Note: fixed several latent bugs found while validating — the SPA fallback
+    was mounted before the API router (so `/health` returned `index.html` for
+    any `Accept: */*` request, including the Docker healthcheck and Render
+    probe); the CORS wildcard matcher did not escape regex metacharacters (so
+    `darkmoon-dev.netlify.app` also matched look-alike hosts); a bare
+    `ALLOWED_ORIGINS=*` combined with `credentials: true` would have reflected
+    every origin (CWE-942), so `parseAllowedOrigins` now drops a literal `*`
+    entry; `/health`'s `maxPlayers` was not validated, so `NaN`/negative/
+    non-integer values could serialize as `null` or pin the server to
+    `degraded` forever; an unset/invalid `PORT` reached `app.listen(NaN)` with
+    no diagnostic; and the `player-tagged` handler trusted a client-supplied
+    `taggerId`, letting any connected client impersonate the current IT player.
 
 - [ ] Re-baseline the remaining large-file refactor work.
   - Priority: P2
@@ -136,10 +146,10 @@ Last Updated: 2026-08-21
 
 - [ ] Fix server-side multiplayer tag parity before Multiplayer Tag ships.
   - Priority: P1
-  - Problem: `server/index.js`'s `player-tagged` handler has no cooldown/freeze enforcement and trusts client-supplied tagger/tagged IDs, and its `disconnect` handler doesn't reassign or clear `itPlayerId` if the IT player disconnects.
+  - Problem: `server/index.js`'s `player-tagged` handler has no cooldown/freeze enforcement, and its `disconnect` handler doesn't reassign or clear `itPlayerId` if the IT player disconnects.
+  - Note (2026-08-27): the client-supplied tagger/tagged ID trust issue is fixed — `taggerId` is now bound to `client.id`, self-tags are rejected, and the broadcast payload always carries the authenticated IDs rather than whatever the client sent. Cooldown/freeze enforcement and IT-disconnect handoff remain open.
   - Acceptance Criteria: see `docs/MULTIPLAYER_SHOOTER_ROADMAP.md` "Server-side tag parity"; must be resolved before Multiplayer Tag moves out of `[planned]` in `FEATURES.md`.
 
 ## See also: docs/INSTRUCTIONS.md for agent handoff and workflow best practices.
 
-- Docker-first validation is blocked by the current production build failure.
 - The deployed site presents solo mode as live and multiplayer or tournament work as planned.

--- a/TASKS.md
+++ b/TASKS.md
@@ -113,9 +113,9 @@ Last Updated: 2026-08-21
     `server/port.js` (`PORT` validation), and `server/tagAuthorization.js`
     (pure `player-tagged` authorization decision — impersonation/self-tag/
     unknown-player rejection), plus SIGTERM graceful shutdown in
-    `server/index.js`. Covered by 95 new tests across
+    `server/index.js`. Covered by 96 new tests across
     `src/__tests__/server.{logger,cors,health,port,tagAuthorization}.test.ts`.
-    Full suite: 79 files, 653 passed / 5 skipped; typecheck and lint clean.
+    Full suite: 79 files, 654 passed / 5 skipped; typecheck and lint clean.
   - Note: fixed several latent bugs found while validating — the SPA fallback
     was mounted before the API router (so `/health` returned `index.html` for
     any `Accept: */*` request, including the Docker healthcheck and Render
@@ -123,7 +123,10 @@ Last Updated: 2026-08-21
     `darkmoon-dev.netlify.app` also matched look-alike hosts); a bare
     `ALLOWED_ORIGINS=*` combined with `credentials: true` would have reflected
     every origin (CWE-942), so `parseAllowedOrigins` now drops a literal `*`
-    entry; `/health`'s `maxPlayers` was not validated, so `NaN`/negative/
+    entry; the origin wildcard expanded to `.*` (cross-label) instead of
+    `[^.]*` (single-label), so a deploy-preview pattern could absorb extra
+    attacker-controlled subdomains spliced into the wildcard slot;
+    `/health`'s `maxPlayers` was not validated, so `NaN`/negative/
     non-integer values could serialize as `null` or pin the server to
     `degraded` forever; an unset/invalid `PORT` reached `app.listen(NaN)` with
     no diagnostic; and the `player-tagged` handler trusted a client-supplied

--- a/TASKS.md
+++ b/TASKS.md
@@ -115,7 +115,11 @@ Last Updated: 2026-08-27
     unknown-player rejection), plus SIGTERM graceful shutdown in
     `server/index.js`. Covered by 96 new tests across
     `src/__tests__/server.{logger,cors,health,port,tagAuthorization}.test.ts`.
-    Full suite: 79 files, 654 passed / 5 skipped; typecheck and lint clean.
+    Full suite (`docker build --target test -t darkmoon:test .` then
+    `docker run --rm darkmoon:test`, which runs `npm run test:run` →
+    `vitest run --config ./config/vitest.config.ts --configLoader runner`;
+    scope excludes only `e2e/**`, matching the 79-file/5-skipped figures
+    above): 79 files, 654 passed / 5 skipped; typecheck and lint clean.
   - Note: fixed several latent bugs found while validating — the SPA fallback
     was mounted before the API router (so `/health` returned `index.html` for
     any `Accept: */*` request, including the Docker healthcheck and Render

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,6 @@
 # Tasks
 
-Last Updated: 2026-08-21
+Last Updated: 2026-08-27
 
 ## In Progress
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -62,13 +62,13 @@ but not yet driven by a shipped client experience.
 
 ### Client to server
 
-| Event           | Payload                                    | Notes                                          |
-| --------------- | ------------------------------------------ | ---------------------------------------------- |
-| `move`          | `{ position: [x,y,z], rotation: [x,y,z] }` | Validated and rate limited (100/s)             |
-| `chat-message`  | `{ message, playerId, playerName }`        | Validated, profanity filtered, 10/min          |
-| `game-start`    | `{ mode }`                                 | Mode must be `tag`/`collectible`/`race`/`solo` |
-| `player-tagged` | `{ taggerId, taggedId }`                   | Rejected unless the tagger is currently IT     |
-| `game-end`      | none                                       | Resets game state and scores                   |
+| Event           | Payload                                    | Notes                                                                                                                                                                                                                                  |
+| --------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `move`          | `{ position: [x,y,z], rotation: [x,y,z] }` | Validated and rate limited (100/s)                                                                                                                                                                                                     |
+| `chat-message`  | `{ message, playerId, playerName }`        | Validated, profanity filtered, 10/min                                                                                                                                                                                                  |
+| `game-start`    | `{ mode }`                                 | Mode must be `tag`/`collectible`/`race`/`solo`                                                                                                                                                                                         |
+| `player-tagged` | `{ taggedId }`                             | Tagger is always the sending socket (`client.id`), never a client-supplied `taggerId` — this prevents impersonating the IT player. Rejected unless the sender is currently IT, or if `taggedId` is missing/unknown/equal to the tagger |
+| `game-end`      | none                                       | Resets game state and scores                                                                                                                                                                                                           |
 
 ### Server to client
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,18 +2,97 @@
 
 ## HTTP Endpoints
 
-- `GET /health` — Returns 200 OK if the server is running.
+### `GET /health`
+
+Operational status endpoint. Used by the Docker `HEALTHCHECK`, the Render
+`healthCheckPath`, and any external uptime monitor. Always returns JSON.
+
+```json
+{
+  "status": "ok",
+  "timestamp": "2026-08-27T17:43:09.096Z",
+  "uptimeSeconds": 4,
+  "activePlayers": 0,
+  "activeGames": 0,
+  "maxPlayers": 64,
+  "game": { "isActive": false, "mode": "none", "startedAt": null },
+  "version": null
+}
+```
+
+| Field           | Meaning                                                           |
+| --------------- | ----------------------------------------------------------------- |
+| `status`        | `ok`, or `degraded` once `activePlayers >= maxPlayers`            |
+| `uptimeSeconds` | Whole seconds since process start                                 |
+| `activePlayers` | Currently connected players                                       |
+| `activeGames`   | Matches in progress (0 or 1 under the current single-match model) |
+| `game`          | Mode and start time of the active match, if any                   |
+| `version`       | `APP_VERSION` when set, otherwise `null`                          |
+
+HTTP status is `200` for both `ok` and `degraded` — a busy but healthy server
+should not be cycled by the platform. Only a server that cannot produce a report
+returns `503`.
+
+> Route ordering note: the API router is mounted **before** the SPA fallback.
+> `req.accepts("html")` is truthy for `Accept: */*`, so a fallback registered
+> first would answer `/health` with `index.html`.
+
+### `GET /`
+
+Service status summary: `service`, `status`, `connections`, `activePlayers`,
+`activeGames`, `uptimeSeconds`, `timestamp`.
+
+## CORS
+
+One allow-list, configured via `ALLOWED_ORIGINS`, guards both the HTTP app and
+the Socket.io handshake, so anything that can reach `/health` can also open a
+socket. Entries match literally except for `*`, which is a wildcard within the
+entry (used for Netlify deploy previews).
+
+- Allowed origin: request succeeds, `Access-Control-Allow-Origin` is echoed.
+- Rejected origin: `403 {"error":"Origin not allowed"}` plus a
+  `security.cors_rejected` log record.
+- Requests with **no** `Origin` header are allowed (curl, container health
+  checks, native clients).
 
 ## WebSocket (Socket.io) Events
 
-- **Solo Mode**: No active WebSocket events; all logic is client-side.
-- **Multiplayer (Planned)**:
-  - `connect` — Player joins a room
-  - `player-update` — Sync player state
-  - `tag` — Tag action event
-  - `disconnect` — Player leaves
+Multiplayer is still `[planned]`; the events below are implemented server-side
+but not yet driven by a shipped client experience.
+
+### Client to server
+
+| Event           | Payload                                    | Notes                                          |
+| --------------- | ------------------------------------------ | ---------------------------------------------- |
+| `move`          | `{ position: [x,y,z], rotation: [x,y,z] }` | Validated and rate limited (100/s)             |
+| `chat-message`  | `{ message, playerId, playerName }`        | Validated, profanity filtered, 10/min          |
+| `game-start`    | `{ mode }`                                 | Mode must be `tag`/`collectible`/`race`/`solo` |
+| `player-tagged` | `{ taggerId, taggedId }`                   | Rejected unless the tagger is currently IT     |
+| `game-end`      | none                                       | Resets game state and scores                   |
+
+### Server to client
+
+| Event           | Payload                                  |
+| --------------- | ---------------------------------------- |
+| `move`          | Map of all client positions/rotations    |
+| `chat-message`  | Filtered message with a server timestamp |
+| `game-start`    | `{ ...gameData, itPlayerId, startTime }` |
+| `player-tagged` | `{ ...data, scores }`                    |
+| `game-end`      | none                                     |
+| `error`         | `{ message }` for validation/rate limits |
+| `game-error`    | `{ message }` for rejected game actions  |
+
+> `scores` on `player-tagged` is additive; existing clients that ignore the
+> field are unaffected.
+
+## Logging
+
+All server output is newline-delimited JSON with `timestamp`, `level`, and a
+stable `event` key. See `docs/MULTIPLAYER_GATE.md` for the event catalogue.
 
 ## Deployment Contracts
 
-- **Docker**: Exposes port 4444, runs as non-root user, healthcheck on `/`.
-- **Netlify**: Static frontend only, no server-side multiplayer.
+- **Docker**: exposes port 4444, runs as a non-root user, `HEALTHCHECK` asserts
+  the `/health` payload, and `SIGTERM` triggers a graceful shutdown.
+- **Render**: `healthCheckPath: /health`; `ALLOWED_ORIGINS` set per environment.
+- **Netlify**: static frontend only, no server-side multiplayer.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,8 +23,20 @@ Darkmoon is a solo-first 3D browser game built with React 19, Three Fiber, Vite,
 
 ## Health/Socket Contracts
 
-- **/health**: HTTP GET returns 200 OK if server is running.
+- **/health**: HTTP GET returning server status, uptime, active player count, and
+  active game count as JSON. Mounted before the SPA fallback so it is reachable
+  for every `Accept` header. See `docs/API.md`.
 - **WebSocket**: Socket.io events for multiplayer (planned), not active in solo mode.
+- **CORS**: one `ALLOWED_ORIGINS` allow-list guards both the HTTP app and the
+  Socket.io handshake (`server/cors.js`).
+- **Logging**: all server output is newline-delimited JSON (`server/logger.js`).
+- **Shutdown**: `SIGTERM`/`SIGINT` drain connections and exit 0.
+
+## Multiplayer Readiness Gate
+
+`docs/MULTIPLAYER_GATE.md` defines the pass/fail bar the server must clear
+before Multiplayer Tag can ship: deployment, CORS, logging, and observability,
+each with a runnable acceptance check.
 
 ## Related
 

--- a/docs/MULTIPLAYER_GATE.md
+++ b/docs/MULTIPLAYER_GATE.md
@@ -1,0 +1,286 @@
+# Multiplayer Readiness Gate
+
+Last Updated: 2026-08-27
+
+## Purpose
+
+Multiplayer Tag stays `[planned]` in `FEATURES.md` until the server it depends
+on is demonstrably deployable, reachable, observable, and debuggable. This
+document defines that bar as four criteria, each with a **testable acceptance
+check** — a command anyone can run to get a pass/fail answer, not a judgement
+call.
+
+This gate covers the **server's readiness to host multiplayer**. It deliberately
+does not cover multiplayer _gameplay_ correctness; see "Out of scope" below.
+
+**Current status: all four criteria pass** (verified 2026-08-27).
+
+| #   | Criterion     | Status  |
+| --- | ------------- | ------- |
+| 1   | Deployment    | ✅ Pass |
+| 2   | CORS          | ✅ Pass |
+| 3   | Logging       | ✅ Pass |
+| 4   | Observability | ✅ Pass |
+
+---
+
+## Criterion 1 — Deployment
+
+**Description.** The server must build into a production image, start from a
+clean environment, be reachable through a reverse proxy that can carry
+WebSockets, and shut down without dropping the platform's deploy signal.
+
+Requirements:
+
+1. The production image builds (`--target runner`) and starts with no arguments.
+2. Configuration is environment-driven (`PORT`, `ALLOWED_ORIGINS`, `LOG_LEVEL`),
+   with working defaults, and documented in `.env.example`.
+3. The container `HEALTHCHECK` targets `/health` and validates the payload.
+4. `SIGTERM` drains connections and exits `0` within 10s (platforms send
+   `SIGTERM` on deploy and scale-down; a server that ignores it is killed
+   mid-match).
+5. The reverse proxy configuration required for WebSocket upgrade is documented.
+
+### Acceptance check
+
+```bash
+# 1. Production image builds and boots
+docker build --target runner -t darkmoon-prod .
+docker run -d --name gate -p 4444:4444 darkmoon-prod
+
+# 2. Graceful shutdown: expect exit code 0 and a server.shutdown log record
+docker kill --signal=SIGTERM gate
+docker inspect -f '{{.State.ExitCode}}' gate   # → 0
+```
+
+**Pass when** the image builds, the server boots with no arguments, and SIGTERM
+produces exit code `0` plus a `server.shutdown` record.
+
+### Reverse proxy configuration
+
+Socket.io needs the HTTP `Upgrade`/`Connection` headers forwarded, or it
+silently degrades to long-polling (and fails outright behind proxies with a
+short idle timeout). The timeout must exceed Socket.io's 60s ping interval.
+
+**nginx:**
+
+```nginx
+location / {
+    proxy_pass         http://127.0.0.1:4444;
+    proxy_http_version 1.1;
+
+    # Required for the WebSocket upgrade handshake
+    proxy_set_header   Upgrade    $http_upgrade;
+    proxy_set_header   Connection "upgrade";
+
+    proxy_set_header   Host              $host;
+    proxy_set_header   X-Real-IP         $remote_addr;
+    proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header   X-Forwarded-Proto $scheme;
+
+    # Must exceed the 60s Socket.io ping interval
+    proxy_read_timeout 120s;
+    proxy_send_timeout 120s;
+}
+```
+
+**Caddy:**
+
+```
+darkmoon.example.com {
+    reverse_proxy 127.0.0.1:4444
+}
+```
+
+**Render** (current target, `render.yaml`) terminates TLS and forwards
+WebSocket upgrades automatically; it needs only `healthCheckPath: /health` and
+per-environment `ALLOWED_ORIGINS`. If the app ever sits behind a proxy that sets
+`X-Forwarded-For`, enable `app.set("trust proxy", 1)` so `express-rate-limit`
+buckets by real client IP instead of the proxy's.
+
+---
+
+## Criterion 2 — CORS
+
+**Description.** A single explicit origin allow-list must guard both the HTTP
+app and the Socket.io handshake. Two policies that can drift are a
+deployment-day outage: the page loads, then the socket refuses to connect.
+
+Requirements:
+
+1. Allowed origins come from `ALLOWED_ORIGINS`, with a documented default.
+2. The **same** policy object is applied to Express and to Socket.io.
+3. Wildcards (`*`) work for Netlify deploy previews, and every other character
+   matches literally — `darkmoon-dev.netlify.app` must not match
+   `darkmoon-devXnetlify.app`.
+4. Patterns are anchored, so a suffix like
+   `darkmoon-dev.netlify.app.evil.example` is rejected.
+5. A rejected origin returns `403` with a JSON body and a log record — not a
+   `500` with a stack trace.
+6. Requests with no `Origin` header (curl, health checks, native clients) are
+   allowed.
+
+### Acceptance check
+
+```bash
+npx vitest run src/__tests__/server.cors.test.ts
+
+# Live check against a running server
+curl -s -o /dev/null -w '%{http_code}\n' -H 'Origin: https://darkmoon-dev.netlify.app' localhost:4444/health   # → 200
+curl -s -o /dev/null -w '%{http_code}\n' -H 'Origin: https://evil.example'             localhost:4444/health   # → 403
+```
+
+**Pass when** the suite is green, an allowed origin gets `200` with the origin
+echoed in `Access-Control-Allow-Origin`, and an unlisted origin gets `403`.
+
+Implementation: `server/cors.js`.
+
+---
+
+## Criterion 3 — Logging
+
+**Description.** Every game event must produce a structured, machine-parseable
+record. Debugging a live multiplayer match from prose `console.log` lines is not
+viable — an aggregator has to filter by player and event without regex-parsing
+sentences.
+
+Requirements:
+
+1. Every record is a single line of JSON carrying `timestamp`, `level`, and a
+   stable `event` key.
+2. **No** unstructured output on any path, including error handling.
+3. The required game events are covered: player connect, player disconnect, tag
+   events (accepted _and_ rejected, with a reason), and score changes.
+4. Level is configurable via `LOG_LEVEL`.
+5. Log context can never overwrite the reserved keys, and unserializable context
+   degrades to an error record instead of throwing inside a game handler.
+6. Message bodies (chat) are not logged — metadata only.
+
+### Event catalogue
+
+| Event                        | Level | Key fields                                       |
+| ---------------------------- | ----- | ------------------------------------------------ |
+| `server.started`             | info  | `port`, `allowedOrigins`, `logLevel`             |
+| `server.shutdown`            | info  | `signal`, `activePlayers`, `uptimeSeconds`       |
+| `player.connected`           | info  | `playerId`, `activePlayers`                      |
+| `player.disconnected`        | info  | `playerId`, `activePlayers`, `wasIt`             |
+| `game.player_tagged`         | info  | `taggerId`, `taggedId`, `mode`                   |
+| `game.tag_rejected`          | warn  | `taggerId`, `taggedId`, `reason`                 |
+| `game.score_changed`         | info  | `playerId`, `previousScore`, `newScore`, `delta` |
+| `game.started`               | info  | `mode`, `itPlayerId`, `playerCount`              |
+| `game.ended`                 | info  | `mode`, `durationMs`, `finalScores`              |
+| `chat.message`               | info  | `playerId`, `messageLength` (never the body)     |
+| `security.rate_limited`      | warn  | `playerId`, `action`                             |
+| `security.validation_failed` | warn  | `playerId`, `field`                              |
+| `security.cors_rejected`     | warn  | `origin`, `transport`                            |
+
+### Acceptance check
+
+```bash
+npx vitest run src/__tests__/server.logger.test.ts
+
+# Every emitted line must parse as JSON
+docker logs <container> 2>&1 | while read -r line; do
+  echo "$line" | jq -e . >/dev/null || { echo "NOT JSON: $line"; exit 1; }
+done
+```
+
+**Pass when** the suite is green and every log line parses as JSON.
+
+Sample output from a full lifecycle:
+
+```json
+{"service":"darkmoon-server","port":4444,"logLevel":"info","timestamp":"2026-08-27T17:44:53.173Z","level":"info","event":"server.started"}
+{"service":"darkmoon-server","playerId":"fH_QSHUUaSIA2ypO","activePlayers":1,"timestamp":"2026-08-27T17:44:57.325Z","level":"info","event":"player.connected"}
+{"service":"darkmoon-server","playerId":"fH_QSHUUaSIA2ypO","activePlayers":0,"wasIt":false,"timestamp":"2026-08-27T17:44:57.928Z","level":"info","event":"player.disconnected"}
+{"service":"darkmoon-server","signal":"SIGTERM","activePlayers":0,"uptimeSeconds":7,"timestamp":"2026-08-27T17:45:00.707Z","level":"info","event":"server.shutdown"}
+```
+
+Implementation: `server/logger.js`.
+
+---
+
+## Criterion 4 — Observability
+
+**Description.** `/health` must answer "is the server up, and what is it doing
+right now?" without shell access — server status, active player count, and
+active game count.
+
+Requirements:
+
+1. `GET /health` returns JSON with `status`, `uptimeSeconds`, `activePlayers`,
+   `activeGames`, and a `game` summary.
+2. It is reachable for **all** `Accept` headers, including `*/*` and
+   `text/html`. (Regression guard: the API router must be mounted before the SPA
+   fallback — see below.)
+3. `status` is `ok`, or `degraded` at/above `maxPlayers`. Both return `200`, so
+   a busy-but-healthy server is not cycled by the platform.
+4. Counts reflect live socket state.
+5. The payload is a pure function of a state snapshot, so it is unit-testable
+   without binding a port.
+
+> **Why requirement 2 exists.** The SPA fallback was previously registered
+> before the API router. `req.accepts("html")` is truthy for `Accept: */*` —
+> which curl, the Docker `HEALTHCHECK`, and platform probes all send — so every
+> `/health` request was answered with `index.html` and the endpoint never ran.
+> The platform health check "passed" while reporting nothing. Any change to
+> middleware order must keep the router first.
+
+### Acceptance check
+
+```bash
+npx vitest run src/__tests__/server.health.test.ts
+
+curl -s localhost:4444/health | jq -e '.status and (.activePlayers >= 0) and (.activeGames >= 0)'
+curl -s -H 'Accept: text/html' localhost:4444/health | jq -e '.status'   # must be JSON, not HTML
+```
+
+**Pass when** the suite is green and both curl calls return JSON with a valid
+`status` and non-negative counts.
+
+Verified live with one connected socket:
+
+```json
+{
+  "status": "ok",
+  "uptimeSeconds": 16,
+  "activePlayers": 1,
+  "activeGames": 0,
+  "maxPlayers": 64,
+  "game": { "isActive": false, "mode": "none", "startedAt": null },
+  "version": null
+}
+```
+
+Implementation: `server/health.js`.
+
+---
+
+## Running the whole gate
+
+```bash
+# Unit criteria (CORS, logging, observability)
+docker compose -f config/docker-compose.yml --profile test run --rm test \
+  npx vitest run --config ./config/vitest.config.ts --configLoader runner \
+  src/__tests__/server.cors.test.ts \
+  src/__tests__/server.logger.test.ts \
+  src/__tests__/server.health.test.ts
+
+# Full suite (must stay green)
+docker compose -f config/docker-compose.yml --profile test run --rm test
+```
+
+## Out of scope
+
+This gate certifies that the server can be **operated**. It does not certify
+that multiplayer tag is **correct**. Two known gameplay gaps remain tracked
+separately in `TASKS.md` and must also close before Multiplayer Tag ships:
+
+- `player-tagged` enforces no cooldown/freeze window, so server-side tag rules
+  do not match the client's `GameManager` parity rules.
+- A disconnecting IT player does not hand off or clear `itPlayerId`, so a match
+  can be left with nobody IT.
+
+Both are logged (`game.tag_rejected` with a reason, and `wasIt` on
+`player.disconnected`), so the gate's observability makes them diagnosable — it
+does not make them fixed.

--- a/docs/MULTIPLAYER_GATE.md
+++ b/docs/MULTIPLAYER_GATE.md
@@ -22,6 +22,15 @@ does not cover multiplayer _gameplay_ correctness; see "Out of scope" below.
 | 3   | Logging       | ✅ Pass |
 | 4   | Observability | ✅ Pass |
 
+> **Accepted risk: unauthenticated `/health`.** The endpoint returns active
+> player/game counts, capacity, uptime, and version with no auth. This is
+> deliberate — Render's `healthCheckPath` and the container `HEALTHCHECK`
+> both probe it unauthenticated, and none of the exposed fields are
+> per-player identifying data (no player IDs, positions, or chat content).
+> The disclosure is aggregate operational status, not gameplay data, so it
+> does not block this gate. Revisit if `/health` ever grows a field that
+> identifies an individual player.
+
 ---
 
 ## Criterion 1 — Deployment
@@ -48,13 +57,17 @@ Requirements:
 docker build --target runner -t darkmoon-prod .
 docker run -d --name gate -p 4444:4444 darkmoon-prod
 
-# 2. Graceful shutdown: expect exit code 0 and a server.shutdown log record
+# 2. Graceful shutdown: send SIGTERM, then block until the container actually
+# exits (docker wait) instead of inspecting state that may still say "running".
 docker kill --signal=SIGTERM gate
-docker inspect -f '{{.State.ExitCode}}' gate   # → 0
+EXIT_CODE=$(timeout 10 docker wait gate)   # blocks until exit or 10s timeout
+echo "$EXIT_CODE"   # → 0
+docker logs gate 2>&1 | tail -n 5 | jq -e 'select(.event == "server.shutdown")'
 ```
 
-**Pass when** the image builds, the server boots with no arguments, and SIGTERM
-produces exit code `0` plus a `server.shutdown` record.
+**Pass when** the image builds, the server boots with no arguments, `docker
+wait` reports exit code `0` within 10s, and a `server.shutdown` record appears
+in the logs.
 
 ### Reverse proxy configuration
 
@@ -86,7 +99,7 @@ location / {
 
 **Caddy:**
 
-```
+```caddy
 darkmoon.example.com {
     reverse_proxy 127.0.0.1:4444
 }
@@ -125,13 +138,19 @@ Requirements:
 ```bash
 npx vitest run src/__tests__/server.cors.test.ts
 
-# Live check against a running server
-curl -s -o /dev/null -w '%{http_code}\n' -H 'Origin: https://darkmoon-dev.netlify.app' localhost:4444/health   # → 200
-curl -s -o /dev/null -w '%{http_code}\n' -H 'Origin: https://evil.example'             localhost:4444/health   # → 403
+# Live check against a running server — capture headers and body, not just the
+# status code, so the allow-list and the rejection contract are both proven.
+curl -s -D - -o body-allowed.json -H 'Origin: https://darkmoon-dev.netlify.app' localhost:4444/health
+grep -i '^Access-Control-Allow-Origin: https://darkmoon-dev.netlify.app' <(curl -si -H 'Origin: https://darkmoon-dev.netlify.app' localhost:4444/health)
+
+curl -s -D - -o body-rejected.json -w '%{http_code}\n' -H 'Origin: https://evil.example' localhost:4444/health   # → 403
+jq -e '.error' body-rejected.json   # rejection body is JSON, not an HTML stack trace
+docker logs <container> 2>&1 | tail -n 5 | jq -e 'select(.event == "security.cors_rejected" and .origin == "https://evil.example")'
 ```
 
 **Pass when** the suite is green, an allowed origin gets `200` with the origin
-echoed in `Access-Control-Allow-Origin`, and an unlisted origin gets `403`.
+echoed back in `Access-Control-Allow-Origin`, and an unlisted origin gets `403`
+with a JSON body and a matching `security.cors_rejected` log record.
 
 Implementation: `server/cors.js`.
 
@@ -231,12 +250,16 @@ Requirements:
 ```bash
 npx vitest run src/__tests__/server.health.test.ts
 
-curl -s localhost:4444/health | jq -e '.status and (.activePlayers >= 0) and (.activeGames >= 0)'
+# Require HTTP 200 (a 503 with a plausible-looking body must not pass) and a
+# status strictly in {ok, degraded} — jq's truthiness accepts "error" too, so
+# the check has to name the allowed values explicitly.
+curl -s -o /dev/null -w '%{http_code}\n' localhost:4444/health   # → 200
+curl -s localhost:4444/health | jq -e '(.status == "ok" or .status == "degraded") and (.activePlayers >= 0) and (.activeGames >= 0)'
 curl -s -H 'Accept: text/html' localhost:4444/health | jq -e '.status'   # must be JSON, not HTML
 ```
 
-**Pass when** the suite is green and both curl calls return JSON with a valid
-`status` and non-negative counts.
+**Pass when** the suite is green, the endpoint returns HTTP `200`, and the body
+is JSON with `status` exactly `ok` or `degraded` plus non-negative counts.
 
 Verified live with one connected socket:
 

--- a/docs/MULTIPLAYER_GATE.md
+++ b/docs/MULTIPLAYER_GATE.md
@@ -138,10 +138,12 @@ Requirements:
 ```bash
 npx vitest run src/__tests__/server.cors.test.ts
 
-# Live check against a running server — capture headers and body, not just the
-# status code, so the allow-list and the rejection contract are both proven.
-curl -s -D - -o body-allowed.json -H 'Origin: https://darkmoon-dev.netlify.app' localhost:4444/health
-grep -i '^Access-Control-Allow-Origin: https://darkmoon-dev.netlify.app' <(curl -si -H 'Origin: https://darkmoon-dev.netlify.app' localhost:4444/health)
+# Live check against a running server — one request, asserting status code
+# AND the echoed header (checking either alone would miss a server that gets
+# the other wrong).
+STATUS=$(curl -s -D headers-allowed.txt -o body-allowed.json -w '%{http_code}' \
+  -H 'Origin: https://darkmoon-dev.netlify.app' localhost:4444/health)
+test "$STATUS" = "200" && grep -qi '^Access-Control-Allow-Origin: https://darkmoon-dev.netlify.app' headers-allowed.txt && echo "allowed origin: PASS"
 
 curl -s -D - -o body-rejected.json -w '%{http_code}\n' -H 'Origin: https://evil.example' localhost:4444/health   # → 403
 jq -e '.error' body-rejected.json   # rejection body is JSON, not an HTML stack trace

--- a/server/cors.d.ts
+++ b/server/cors.d.ts
@@ -2,6 +2,8 @@ export type CorsOriginCallback = (err: Error | null, allow?: boolean) => void;
 
 export type OriginRejectionHook = (event: { origin: string }) => void;
 
+export type UnsafeWildcardHook = (event: { entry: string }) => void;
+
 export interface CorsOptions {
   origin: (origin: string | undefined, callback: CorsOriginCallback) => void;
   methods: string[];
@@ -16,7 +18,9 @@ export function createCorsError(): Error & {
 };
 export function parseAllowedOrigins(
   envValue: string | undefined | null,
+  onUnsafeWildcard?: UnsafeWildcardHook,
 ): string[];
+export function isUnsafeWildcard(entry: string): boolean;
 export function matchesOrigin(origin: string, allowedOrigin: string): boolean;
 export function isOriginAllowed(
   origin: string | undefined | null,
@@ -35,6 +39,7 @@ declare const _default: {
   DEFAULT_ALLOWED_ORIGINS: typeof DEFAULT_ALLOWED_ORIGINS;
   CORS_ERROR_CODE: typeof CORS_ERROR_CODE;
   parseAllowedOrigins: typeof parseAllowedOrigins;
+  isUnsafeWildcard: typeof isUnsafeWildcard;
   matchesOrigin: typeof matchesOrigin;
   isOriginAllowed: typeof isOriginAllowed;
   createCorsError: typeof createCorsError;

--- a/server/cors.d.ts
+++ b/server/cors.d.ts
@@ -1,0 +1,44 @@
+export type CorsOriginCallback = (err: Error | null, allow?: boolean) => void;
+
+export type OriginRejectionHook = (event: { origin: string }) => void;
+
+export interface CorsOptions {
+  origin: (origin: string | undefined, callback: CorsOriginCallback) => void;
+  methods: string[];
+  credentials: boolean;
+}
+
+export const DEFAULT_ALLOWED_ORIGINS: string[];
+export const CORS_ERROR_CODE: string;
+export function createCorsError(): Error & {
+  code: string;
+  statusCode: number;
+};
+export function parseAllowedOrigins(
+  envValue: string | undefined | null,
+): string[];
+export function matchesOrigin(origin: string, allowedOrigin: string): boolean;
+export function isOriginAllowed(
+  origin: string | undefined | null,
+  allowedOrigins: string[],
+): boolean;
+export function createOriginCallback(
+  allowedOrigins: string[],
+  onRejected?: OriginRejectionHook,
+): (origin: string | undefined, callback: CorsOriginCallback) => void;
+export function createCorsOptions(
+  allowedOrigins: string[],
+  onRejected?: OriginRejectionHook,
+): CorsOptions;
+
+declare const _default: {
+  DEFAULT_ALLOWED_ORIGINS: typeof DEFAULT_ALLOWED_ORIGINS;
+  CORS_ERROR_CODE: typeof CORS_ERROR_CODE;
+  parseAllowedOrigins: typeof parseAllowedOrigins;
+  matchesOrigin: typeof matchesOrigin;
+  isOriginAllowed: typeof isOriginAllowed;
+  createCorsError: typeof createCorsError;
+  createOriginCallback: typeof createOriginCallback;
+  createCorsOptions: typeof createCorsOptions;
+};
+export default _default;

--- a/server/cors.d.ts
+++ b/server/cors.d.ts
@@ -2,7 +2,11 @@ export type CorsOriginCallback = (err: Error | null, allow?: boolean) => void;
 
 export type OriginRejectionHook = (event: { origin: string }) => void;
 
-export type UnsafeWildcardHook = (event: { entry: string }) => void;
+export interface UnsafeWildcardEvent {
+  entry: string;
+}
+
+export type UnsafeWildcardHook = (event: UnsafeWildcardEvent) => void;
 
 export interface CorsOptions {
   origin: (origin: string | undefined, callback: CorsOriginCallback) => void;

--- a/server/cors.js
+++ b/server/cors.js
@@ -70,16 +70,24 @@ export const parseAllowedOrigins = (envValue, onUnsafeWildcard) => {
 export const isUnsafeWildcard = (entry) => entry === "*";
 
 /**
- * Escape regex metacharacters, leaving `*` intact so it can become `.*`.
- * Without this, an entry like `https://darkmoon-dev.netlify.app` would be
+ * Escape regex metacharacters, leaving `*` intact so it can become a
+ * single-label wildcard.
+ *
+ * Without escaping, an entry like `https://darkmoon-dev.netlify.app` would be
  * compiled with `.` as "any character" and would match hostile look-alike
  * origins such as `https://darkmoon-devxnetlify.app`.
+ *
+ * `*` expands to `[^.]*` rather than `.*` so it matches only within a single
+ * DNS label. A cross-label `.*` would let a deploy-preview pattern like
+ * `https://deploy-preview-*--darkmoon-dev.netlify.app` also match an origin
+ * with extra, attacker-controlled subdomains spliced into the wildcard slot
+ * (e.g. `https://deploy-preview-1.attacker.example--darkmoon-dev.netlify.app`).
  *
  * @param {string} pattern - Allow-list entry.
  * @returns {string} Regex source escaped everywhere except `*`.
  */
 const escapeExceptWildcard = (pattern) =>
-  pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+  pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, "[^.]*");
 
 /**
  * Test a single origin against a single allow-list entry.

--- a/server/cors.js
+++ b/server/cors.js
@@ -25,23 +25,49 @@ export const DEFAULT_ALLOWED_ORIGINS = [
  * Parse the `ALLOWED_ORIGINS` env var into a normalized allow-list.
  *
  * Empty/whitespace-only entries are dropped, and each entry is trimmed so that
- * `"a, b"` and `"a,b"` behave identically. Falls back to
- * {@link DEFAULT_ALLOWED_ORIGINS} when the value is missing or contains no
- * usable entries.
+ * `"a, b"` and `"a,b"` behave identically. A bare `*` entry is also dropped
+ * (see {@link isUnsafeWildcard}) rather than kept, since `createCorsOptions`
+ * always sets `credentials: true` and reflecting every origin under that
+ * combination (CWE-942) would let any site make authenticated requests as a
+ * logged-in player. Falls back to {@link DEFAULT_ALLOWED_ORIGINS} when the
+ * value is missing or contains no usable entries after filtering.
  *
  * @param {string | undefined | null} envValue - Raw env var value.
+ * @param {(event: { entry: string }) => void} [onUnsafeWildcard] - Optional
+ *   hook invoked once per bare-`*` entry that gets dropped, used for
+ *   structured logging so a misconfiguration is visible instead of silently
+ *   downgraded.
  * @returns {string[]} Normalized allow-list (never empty).
  */
-export const parseAllowedOrigins = (envValue) => {
+export const parseAllowedOrigins = (envValue, onUnsafeWildcard) => {
   if (typeof envValue !== "string") return [...DEFAULT_ALLOWED_ORIGINS];
 
   const parsed = envValue
     .split(",")
     .map((origin) => origin.trim())
-    .filter((origin) => origin.length > 0);
+    .filter((origin) => origin.length > 0)
+    .filter((origin) => {
+      if (!isUnsafeWildcard(origin)) return true;
+      if (typeof onUnsafeWildcard === "function")
+        onUnsafeWildcard({ entry: origin });
+      return false;
+    });
 
   return parsed.length > 0 ? parsed : [...DEFAULT_ALLOWED_ORIGINS];
 };
+
+/**
+ * A bare `*` (optionally with surrounding whitespace, already trimmed by the
+ * caller) matches every origin once compiled by {@link matchesOrigin}. Unlike
+ * a scoped wildcard such as `https://deploy-preview-*--darkmoon-dev.netlify.app`,
+ * it carries no host constraint at all, so allowing it here would combine
+ * with `credentials: true` to permit any origin to make authenticated
+ * cross-site requests (CWE-942).
+ *
+ * @param {string} entry - Single allow-list entry.
+ * @returns {boolean} True when the entry is exactly `*`.
+ */
+export const isUnsafeWildcard = (entry) => entry === "*";
 
 /**
  * Escape regex metacharacters, leaving `*` intact so it can become `.*`.
@@ -154,6 +180,7 @@ export default {
   DEFAULT_ALLOWED_ORIGINS,
   CORS_ERROR_CODE,
   parseAllowedOrigins,
+  isUnsafeWildcard,
   matchesOrigin,
   isOriginAllowed,
   createCorsError,

--- a/server/cors.js
+++ b/server/cors.js
@@ -1,0 +1,162 @@
+/**
+ * CORS origin policy for the multiplayer WebSocket/HTTP server.
+ *
+ * The same allow-list is applied to the Express HTTP app and to the Socket.io
+ * handshake so that a browser that can reach `/health` can also open a socket.
+ *
+ * Origins are configured via the `ALLOWED_ORIGINS` environment variable as a
+ * comma-separated list. A `*` inside an entry acts as a wildcard for a single
+ * chunk of the origin (used for Netlify deploy previews); every other character
+ * is matched literally.
+ */
+
+/**
+ * Default allow-list used when `ALLOWED_ORIGINS` is not set.
+ * @type {string[]}
+ */
+export const DEFAULT_ALLOWED_ORIGINS = [
+  "http://localhost:3000",
+  "http://localhost:4444",
+  "https://deploy-preview-*--darkmoon-dev.netlify.app",
+  "https://darkmoon-dev.netlify.app",
+];
+
+/**
+ * Parse the `ALLOWED_ORIGINS` env var into a normalized allow-list.
+ *
+ * Empty/whitespace-only entries are dropped, and each entry is trimmed so that
+ * `"a, b"` and `"a,b"` behave identically. Falls back to
+ * {@link DEFAULT_ALLOWED_ORIGINS} when the value is missing or contains no
+ * usable entries.
+ *
+ * @param {string | undefined | null} envValue - Raw env var value.
+ * @returns {string[]} Normalized allow-list (never empty).
+ */
+export const parseAllowedOrigins = (envValue) => {
+  if (typeof envValue !== "string") return [...DEFAULT_ALLOWED_ORIGINS];
+
+  const parsed = envValue
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+
+  return parsed.length > 0 ? parsed : [...DEFAULT_ALLOWED_ORIGINS];
+};
+
+/**
+ * Escape regex metacharacters, leaving `*` intact so it can become `.*`.
+ * Without this, an entry like `https://darkmoon-dev.netlify.app` would be
+ * compiled with `.` as "any character" and would match hostile look-alike
+ * origins such as `https://darkmoon-devxnetlify.app`.
+ *
+ * @param {string} pattern - Allow-list entry.
+ * @returns {string} Regex source escaped everywhere except `*`.
+ */
+const escapeExceptWildcard = (pattern) =>
+  pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+
+/**
+ * Test a single origin against a single allow-list entry.
+ *
+ * @param {string} origin - Browser-supplied `Origin` header.
+ * @param {string} allowedOrigin - Allow-list entry, possibly containing `*`.
+ * @returns {boolean} True when the origin matches the entry.
+ */
+export const matchesOrigin = (origin, allowedOrigin) => {
+  if (typeof origin !== "string" || typeof allowedOrigin !== "string") {
+    return false;
+  }
+
+  if (!allowedOrigin.includes("*")) return origin === allowedOrigin;
+
+  return new RegExp(`^${escapeExceptWildcard(allowedOrigin)}$`).test(origin);
+};
+
+/**
+ * Check an origin against the whole allow-list.
+ *
+ * A missing origin (`undefined`/`null`/`""`) is allowed: non-browser clients
+ * such as curl, container health checks, and native apps send no `Origin`
+ * header, and CORS is not a defense against those callers anyway.
+ *
+ * @param {string | undefined | null} origin - Browser-supplied `Origin` header.
+ * @param {string[]} allowedOrigins - Allow-list from {@link parseAllowedOrigins}.
+ * @returns {boolean} True when the request should be allowed.
+ */
+export const isOriginAllowed = (origin, allowedOrigins) => {
+  if (!origin) return true;
+  if (!Array.isArray(allowedOrigins)) return false;
+
+  return allowedOrigins.some((allowedOrigin) =>
+    matchesOrigin(origin, allowedOrigin),
+  );
+};
+
+/**
+ * Build the `origin` callback consumed by both the `cors` middleware and the
+ * Socket.io server options.
+ *
+ * @param {string[]} allowedOrigins - Allow-list from {@link parseAllowedOrigins}.
+ * @param {(event: { origin: string }) => void} [onRejected] - Optional hook
+ *   invoked when an origin is rejected, used for structured logging.
+ * @returns {(origin: string | undefined, callback: Function) => void} Origin callback.
+ */
+export const createOriginCallback = (allowedOrigins, onRejected) => {
+  return (origin, callback) => {
+    if (isOriginAllowed(origin, allowedOrigins)) {
+      callback(null, true);
+      return;
+    }
+
+    if (typeof onRejected === "function") {
+      onRejected({ origin });
+    }
+
+    callback(createCorsError());
+  };
+};
+
+/**
+ * Error code tagged onto CORS rejections so the Express error handler can turn
+ * them into a clean 403 instead of a generic 500 with a stack trace.
+ * @type {string}
+ */
+export const CORS_ERROR_CODE = "ERR_CORS_ORIGIN_DENIED";
+
+/**
+ * Build the error passed to the CORS callback on rejection.
+ * @returns {Error & { code: string, statusCode: number }}
+ */
+export const createCorsError = () => {
+  const error = /** @type {Error & { code: string, statusCode: number }} */ (
+    new Error("Not allowed by CORS")
+  );
+  error.code = CORS_ERROR_CODE;
+  error.statusCode = 403;
+  return error;
+};
+
+/**
+ * Build the shared CORS options object (methods/credentials are identical for
+ * the HTTP app and the socket handshake).
+ *
+ * @param {string[]} allowedOrigins - Allow-list from {@link parseAllowedOrigins}.
+ * @param {(event: { origin: string }) => void} [onRejected] - Rejection hook.
+ * @returns {{ origin: Function, methods: string[], credentials: boolean }} CORS options.
+ */
+export const createCorsOptions = (allowedOrigins, onRejected) => ({
+  origin: createOriginCallback(allowedOrigins, onRejected),
+  methods: ["GET", "POST"],
+  credentials: true,
+});
+
+export default {
+  DEFAULT_ALLOWED_ORIGINS,
+  CORS_ERROR_CODE,
+  parseAllowedOrigins,
+  matchesOrigin,
+  isOriginAllowed,
+  createCorsError,
+  createOriginCallback,
+  createCorsOptions,
+};

--- a/server/health.d.ts
+++ b/server/health.d.ts
@@ -1,0 +1,54 @@
+export interface GameStateSnapshot {
+  isActive?: boolean;
+  mode?: string;
+  startTime?: number | null;
+  itPlayerId?: string | null;
+}
+
+export interface HealthReport {
+  status: string;
+  timestamp: string;
+  uptimeSeconds: number;
+  activePlayers: number;
+  activeGames: number;
+  maxPlayers: number;
+  game: {
+    isActive: boolean;
+    mode: string;
+    startedAt: string | null;
+  };
+  version: string | null;
+}
+
+export const STATUS_OK: string;
+export const STATUS_DEGRADED: string;
+export const DEFAULT_MAX_PLAYERS: number;
+
+export function countActiveGames(
+  gameState: GameStateSnapshot | null | undefined,
+): number;
+export function countActivePlayers(snapshot?: {
+  connections?: number;
+  clients?: Record<string, unknown>;
+}): number;
+export function buildHealthReport(snapshot?: {
+  connections?: number;
+  clients?: Record<string, unknown>;
+  gameState?: GameStateSnapshot;
+  startedAt?: number;
+  now?: number;
+  maxPlayers?: number;
+  version?: string;
+}): HealthReport;
+export function healthStatusCode(report: { status?: string }): number;
+
+declare const _default: {
+  STATUS_OK: typeof STATUS_OK;
+  STATUS_DEGRADED: typeof STATUS_DEGRADED;
+  DEFAULT_MAX_PLAYERS: typeof DEFAULT_MAX_PLAYERS;
+  countActiveGames: typeof countActiveGames;
+  countActivePlayers: typeof countActivePlayers;
+  buildHealthReport: typeof buildHealthReport;
+  healthStatusCode: typeof healthStatusCode;
+};
+export default _default;

--- a/server/health.js
+++ b/server/health.js
@@ -75,6 +75,14 @@ export const buildHealthReport = ({
   maxPlayers = DEFAULT_MAX_PLAYERS,
   version,
 } = {}) => {
+  // A NaN or infinite limit would make the comparison below always false and
+  // serialize as null; a negative one would pin the server to "degraded"
+  // forever. Only a finite positive integer is a meaningful capacity.
+  const normalizedMaxPlayers =
+    Number.isInteger(maxPlayers) && maxPlayers > 0
+      ? maxPlayers
+      : DEFAULT_MAX_PLAYERS;
+
   const activePlayers = countActivePlayers({ connections, clients });
   const activeGames = countActiveGames(gameState);
 
@@ -83,7 +91,8 @@ export const buildHealthReport = ({
       ? Math.max(0, Math.floor((now - startedAt) / 1000))
       : 0;
 
-  const status = activePlayers >= maxPlayers ? STATUS_DEGRADED : STATUS_OK;
+  const status =
+    activePlayers >= normalizedMaxPlayers ? STATUS_DEGRADED : STATUS_OK;
 
   return {
     status,
@@ -91,7 +100,7 @@ export const buildHealthReport = ({
     uptimeSeconds,
     activePlayers,
     activeGames,
-    maxPlayers,
+    maxPlayers: normalizedMaxPlayers,
     game: {
       isActive: countActiveGames(gameState) > 0,
       mode: gameState?.mode ?? "none",

--- a/server/health.js
+++ b/server/health.js
@@ -1,0 +1,128 @@
+/**
+ * Operational visibility for the multiplayer server.
+ *
+ * `buildHealthReport` is a pure function over a snapshot of server state so the
+ * `/health` payload can be asserted in unit tests without binding a port or
+ * opening sockets.
+ */
+
+/** Server is up and inside its configured capacity. */
+export const STATUS_OK = "ok";
+/** Server is up but at/over capacity — still serving, not accepting more load. */
+export const STATUS_DEGRADED = "degraded";
+
+/**
+ * Default maximum concurrent players before `/health` reports `degraded`.
+ * Sized for the free Render instance the server currently deploys to.
+ * @type {number}
+ */
+export const DEFAULT_MAX_PLAYERS = 64;
+
+/**
+ * Count games currently in progress.
+ *
+ * The server presently hosts a single global match, so this is 0 or 1. It is
+ * written as a function over game state (rather than a hardcoded boolean) so
+ * that a future room/lobby model can report a real count without changing the
+ * `/health` contract.
+ *
+ * @param {{ isActive?: boolean } | null | undefined} gameState - Global game state.
+ * @returns {number} Number of active games.
+ */
+export const countActiveGames = (gameState) => {
+  if (!gameState || typeof gameState !== "object") return 0;
+  return gameState.isActive === true ? 1 : 0;
+};
+
+/**
+ * Count connected players.
+ *
+ * Prefers the Socket.io engine's `clientsCount` (the transport's own view of
+ * open connections) and falls back to the size of the tracked `clients` map.
+ *
+ * @param {{ connections?: number, clients?: Record<string, unknown> }} snapshot
+ * @returns {number} Number of active players.
+ */
+export const countActivePlayers = ({ connections, clients } = {}) => {
+  if (typeof connections === "number" && Number.isFinite(connections)) {
+    return Math.max(0, connections);
+  }
+  if (clients && typeof clients === "object") {
+    return Object.keys(clients).length;
+  }
+  return 0;
+};
+
+/**
+ * Build the `/health` payload.
+ *
+ * @param {object} snapshot
+ * @param {number} [snapshot.connections] - Socket.io `engine.clientsCount`.
+ * @param {Record<string, unknown>} [snapshot.clients] - Tracked client map.
+ * @param {{ isActive?: boolean, mode?: string, startTime?: number | null, itPlayerId?: string | null }} [snapshot.gameState]
+ * @param {number} [snapshot.startedAt] - Server boot time (ms epoch).
+ * @param {number} [snapshot.now] - Current time (ms epoch), injectable for tests.
+ * @param {number} [snapshot.maxPlayers] - Capacity threshold.
+ * @param {string} [snapshot.version] - Build/app version.
+ * @returns {object} Health report.
+ */
+export const buildHealthReport = ({
+  connections,
+  clients,
+  gameState,
+  startedAt,
+  now = Date.now(),
+  maxPlayers = DEFAULT_MAX_PLAYERS,
+  version,
+} = {}) => {
+  const activePlayers = countActivePlayers({ connections, clients });
+  const activeGames = countActiveGames(gameState);
+
+  const uptimeSeconds =
+    typeof startedAt === "number" && Number.isFinite(startedAt)
+      ? Math.max(0, Math.floor((now - startedAt) / 1000))
+      : 0;
+
+  const status = activePlayers >= maxPlayers ? STATUS_DEGRADED : STATUS_OK;
+
+  return {
+    status,
+    timestamp: new Date(now).toISOString(),
+    uptimeSeconds,
+    activePlayers,
+    activeGames,
+    maxPlayers,
+    game: {
+      isActive: countActiveGames(gameState) > 0,
+      mode: gameState?.mode ?? "none",
+      startedAt:
+        typeof gameState?.startTime === "number"
+          ? new Date(gameState.startTime).toISOString()
+          : null,
+    },
+    version: version ?? null,
+  };
+};
+
+/**
+ * HTTP status code for a health report. `degraded` still returns 200 so that a
+ * busy-but-healthy server is not cycled by the platform health check; only a
+ * failure to produce a report at all is a 503.
+ *
+ * @param {{ status?: string }} report
+ * @returns {number} HTTP status code.
+ */
+export const healthStatusCode = (report) =>
+  report?.status === STATUS_OK || report?.status === STATUS_DEGRADED
+    ? 200
+    : 503;
+
+export default {
+  STATUS_OK,
+  STATUS_DEGRADED,
+  DEFAULT_MAX_PLAYERS,
+  countActiveGames,
+  countActivePlayers,
+  buildHealthReport,
+  healthStatusCode,
+};

--- a/server/index.js
+++ b/server/index.js
@@ -8,17 +8,26 @@ import {
   validateChatMessage,
   validateGameMode,
 } from "./validation.js";
+import { createLogger, GAME_EVENTS } from "./logger.js";
+import {
+  parseAllowedOrigins,
+  createCorsOptions,
+  CORS_ERROR_CODE,
+} from "./cors.js";
+import { buildHealthReport, healthStatusCode } from "./health.js";
 
 // Environment configuration
 const PORT = process.env.PORT ? Number(process.env.PORT) : 4444;
-const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS
-  ? process.env.ALLOWED_ORIGINS.split(",")
-  : [
-      "http://localhost:3000",
-      "http://localhost:4444",
-      "https://deploy-preview-*--darkmoon-dev.netlify.app",
-      "https://darkmoon-dev.netlify.app",
-    ];
+const ALLOWED_ORIGINS = parseAllowedOrigins(process.env.ALLOWED_ORIGINS);
+const SERVER_STARTED_AT = Date.now();
+const APP_VERSION = process.env.APP_VERSION || null;
+
+// Structured JSON logger. Every server log line is a single JSON object so log
+// aggregators can index fields directly. Level is controlled by LOG_LEVEL.
+const logger = createLogger({
+  level: process.env.LOG_LEVEL,
+  base: { service: "darkmoon-server" },
+});
 
 // Rate limiting configuration. Limits are applied per-client within a time
 // window (see checkRateLimit windowMs parameter). The default window used by
@@ -37,7 +46,7 @@ const rateLimitTrackers = new Map();
  * Clean up old rate limit entries to prevent memory leaks
  * Runs every 5 minutes
  */
-setInterval(() => {
+const rateLimitCleanupTimer = setInterval(() => {
   const now = Date.now();
   const keysToDelete = [];
 
@@ -51,9 +60,7 @@ setInterval(() => {
   keysToDelete.forEach((key) => rateLimitTrackers.delete(key));
 
   if (keysToDelete.length > 0) {
-    console.log(
-      `[Rate Limit Cleanup] Removed ${keysToDelete.length} stale entries`,
-    );
+    logger.debug("ratelimit.cleanup", { removedEntries: keysToDelete.length });
   }
 }, 300000); // Run every 5 minutes
 
@@ -96,22 +103,38 @@ const checkRateLimit = (clientId, action, limit, windowMs = 1000) => {
 // Create router (Express 5 has native async support)
 const router = express.Router();
 
-// Health check endpoint
-router.get("/health", (req, res) => {
-  res.json({
-    status: "ok",
-    timestamp: new Date().toISOString(),
+/**
+ * Build the current health snapshot from live server state.
+ * @returns {object} Health report.
+ */
+const currentHealthReport = () =>
+  buildHealthReport({
     connections: ioServer ? ioServer.engine.clientsCount : 0,
+    clients,
+    gameState,
+    startedAt: SERVER_STARTED_AT,
+    version: APP_VERSION,
   });
+
+// Health / observability endpoint. Reports server status, uptime, active player
+// count, and active game count. Used by the Docker HEALTHCHECK, the Render
+// healthCheckPath, and any external uptime monitor.
+router.get("/health", (req, res) => {
+  const report = currentHealthReport();
+  res.status(healthStatusCode(report)).json(report);
 });
 
 // Main route for production - simple status page
 router.get("/", async (req, res) => {
+  const report = currentHealthReport();
   res.json({
     service: "Multi WebSocket Server",
     status: "running",
-    connections: ioServer ? ioServer.engine.clientsCount : 0,
-    timestamp: new Date().toISOString(),
+    connections: report.activePlayers,
+    activePlayers: report.activePlayers,
+    activeGames: report.activeGames,
+    uptimeSeconds: report.uptimeSeconds,
+    timestamp: report.timestamp,
   });
 });
 
@@ -119,33 +142,13 @@ router.get("/", async (req, res) => {
 
 // Create express app and listen on specified port
 const app = express();
-app.use(
-  cors({
-    origin: (origin, callback) => {
-      // Allow requests with no origin (like mobile apps or curl requests)
-      if (!origin) return callback(null, true);
 
-      // Check if origin is allowed
-      const isAllowed = ALLOWED_ORIGINS.some((allowedOrigin) => {
-        if (allowedOrigin.includes("*")) {
-          const pattern = new RegExp(
-            "^" + allowedOrigin.replace(/\*/g, ".*") + "$",
-          );
-          return pattern.test(origin);
-        }
-        return allowedOrigin === origin;
-      });
-
-      if (isAllowed) {
-        callback(null, true);
-      } else {
-        callback(new Error("Not allowed by CORS"));
-      }
-    },
-    methods: ["GET", "POST"],
-    credentials: true,
-  }),
+// Shared CORS policy: the same allow-list guards the HTTP app and the Socket.io
+// handshake, so anything that can reach /health can also open a socket.
+const corsOptions = createCorsOptions(ALLOWED_ORIGINS, ({ origin }) =>
+  logger.warn(GAME_EVENTS.CORS_REJECTED, { origin, transport: "http" }),
 );
+app.use(cors(corsOptions));
 app.use(express.static("dist"));
 
 const httpLimiter = rateLimit({
@@ -155,6 +158,12 @@ const httpLimiter = rateLimit({
   legacyHeaders: false,
 });
 app.use(httpLimiter);
+
+// API routes must be mounted BEFORE the SPA fallback. `req.accepts("html")` is
+// truthy for `Accept: */*` (curl, the Docker HEALTHCHECK, and platform probes
+// all send it), so a fallback registered first would answer /health with
+// index.html and the endpoint would never run.
+app.use(router);
 
 // Serve index.html for all non-API, non-static routes (SPA support)
 app.use((req, res, next) => {
@@ -166,38 +175,43 @@ app.use((req, res, next) => {
     next();
   }
 });
-app.use(router);
+
+// Central error handler. Keeps every failure path on the structured logger
+// instead of Express's default handler, which prints an unstructured stack
+// trace to stdout and would break the "all log output is JSON" guarantee.
+// The unused `next` parameter is required: Express identifies error handlers by
+// arity, and a 3-argument function is treated as ordinary middleware.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+app.use((err, req, res, next) => {
+  if (err?.code === CORS_ERROR_CODE) {
+    // Already logged by the CORS rejection hook; answer with a clean 403.
+    res.status(403).json({ error: "Origin not allowed" });
+    return;
+  }
+
+  logger.error("http.request_failed", {
+    method: req.method,
+    path: req.path,
+    message: err?.message,
+    code: err?.code,
+  });
+
+  res.status(err?.statusCode || 500).json({ error: "Internal server error" });
+});
 
 const server = app.listen(PORT, () => {
-  console.log(`Server listening on http://localhost:${PORT}...`);
-  console.log(`Allowed origins: ${ALLOWED_ORIGINS.join(", ")}`);
+  logger.info(GAME_EVENTS.SERVER_STARTED, {
+    port: PORT,
+    allowedOrigins: ALLOWED_ORIGINS,
+    logLevel: process.env.LOG_LEVEL || "info",
+    nodeEnv: process.env.NODE_ENV || "development",
+  });
 });
 
 const ioServer = new Server(server, {
-  cors: {
-    origin: (origin, callback) => {
-      // Allow requests with no origin
-      if (!origin) return callback(null, true);
-
-      const isAllowed = ALLOWED_ORIGINS.some((allowedOrigin) => {
-        if (allowedOrigin.includes("*")) {
-          const pattern = new RegExp(
-            "^" + allowedOrigin.replace(/\*/g, ".*") + "$",
-          );
-          return pattern.test(origin);
-        }
-        return allowedOrigin === origin;
-      });
-
-      if (isAllowed) {
-        callback(null, true);
-      } else {
-        callback(new Error("Not allowed by CORS"));
-      }
-    },
-    methods: ["GET", "POST"],
-    credentials: true,
-  },
+  cors: createCorsOptions(ALLOWED_ORIGINS, ({ origin }) =>
+    logger.warn(GAME_EVENTS.CORS_REJECTED, { origin, transport: "websocket" }),
+  ),
 });
 
 let clients = {};
@@ -208,17 +222,39 @@ let gameState = {
   startTime: null,
 };
 
+// Per-player scores for the active match. Reset on game start and game end.
+let scores = {};
+
+/**
+ * Award a point to a player and emit a structured score-change record.
+ * @param {string} playerId - Player receiving the point.
+ * @param {number} delta - Points to add.
+ * @param {string} reason - Why the score changed (e.g. "tag").
+ */
+const awardScore = (playerId, delta, reason) => {
+  const previousScore = scores[playerId] ?? 0;
+  const newScore = previousScore + delta;
+  scores[playerId] = newScore;
+
+  logger.scoreChanged({ playerId, previousScore, newScore, reason });
+  return newScore;
+};
+
 // Socket app msgs
 ioServer.on("connection", (client) => {
-  console.log(
-    `User ${client.id} connected, Total: ${ioServer.engine.clientsCount} users connected`,
-  );
-
   //Add a new client indexed by their id
   clients[client.id] = {
     position: [0, 0, 0],
     rotation: [0, 0, 0],
   };
+
+  // Count from the tracked map rather than engine.clientsCount: the engine
+  // counter has not yet been decremented inside a `disconnect` handler, so the
+  // map is the only source that is accurate on both edges.
+  logger.playerConnected({
+    playerId: client.id,
+    activePlayers: Object.keys(clients).length,
+  });
 
   ioServer.sockets.emit("move", clients);
 
@@ -226,19 +262,28 @@ ioServer.on("connection", (client) => {
   client.on("move", ({ rotation, position }) => {
     // Rate limit check
     if (checkRateLimit(client.id, "move", RATE_LIMITS.MOVE)) {
-      console.warn(`Rate limit exceeded for ${client.id} on move events`);
+      logger.warn(GAME_EVENTS.RATE_LIMITED, {
+        playerId: client.id,
+        action: "move",
+      });
       return;
     }
 
     // Validate input
     if (!validatePosition(position)) {
-      console.warn(`Invalid position from ${client.id}:`, position);
+      logger.warn(GAME_EVENTS.VALIDATION_FAILED, {
+        playerId: client.id,
+        field: "position",
+      });
       client.emit("error", { message: "Invalid position data" });
       return;
     }
 
     if (!validateRotation(rotation)) {
-      console.warn(`Invalid rotation from ${client.id}:`, rotation);
+      logger.warn(GAME_EVENTS.VALIDATION_FAILED, {
+        playerId: client.id,
+        field: "rotation",
+      });
       client.emit("error", { message: "Invalid rotation data" });
       return;
     }
@@ -255,19 +300,30 @@ ioServer.on("connection", (client) => {
   client.on("chat-message", async (message) => {
     // Rate limit check (10 messages per minute)
     if (checkRateLimit(client.id, "chat", RATE_LIMITS.CHAT, 60000)) {
-      console.warn(`Rate limit exceeded for ${client.id} on chat`);
+      logger.warn(GAME_EVENTS.RATE_LIMITED, {
+        playerId: client.id,
+        action: "chat",
+      });
       client.emit("error", { message: "Slow down! Too many messages." });
       return;
     }
 
     // Validate message
     if (!validateChatMessage(message)) {
-      console.warn(`Invalid chat message from ${client.id}`);
+      logger.warn(GAME_EVENTS.VALIDATION_FAILED, {
+        playerId: client.id,
+        field: "chatMessage",
+      });
       client.emit("error", { message: "Invalid message format" });
       return;
     }
 
-    console.log(`Chat message from ${client.id}: ${message.message}`);
+    // Message bodies are user content and are intentionally not logged; only
+    // metadata is recorded.
+    logger.info(GAME_EVENTS.CHAT_MESSAGE, {
+      playerId: client.id,
+      messageLength: message.message.length,
+    });
 
     // Basic profanity filter (configurable in CHAT_PROFANITY) - use helper
     const defaultBadWords = [
@@ -314,18 +370,22 @@ ioServer.on("connection", (client) => {
   client.on("game-start", (gameData) => {
     // Rate limit game actions
     if (checkRateLimit(client.id, "game", RATE_LIMITS.GAME_ACTION)) {
-      console.warn(`Rate limit exceeded for ${client.id} on game actions`);
+      logger.warn(GAME_EVENTS.RATE_LIMITED, {
+        playerId: client.id,
+        action: "game-start",
+      });
       return;
     }
 
     // Validate game mode
     if (gameData && !validateGameMode(gameData.mode)) {
-      console.warn(`Invalid game mode from ${client.id}:`, gameData.mode);
+      logger.warn(GAME_EVENTS.VALIDATION_FAILED, {
+        playerId: client.id,
+        field: "gameMode",
+      });
       client.emit("game-error", { message: "Invalid game mode" });
       return;
     }
-
-    console.log(`Game start requested by ${client.id}:`, gameData);
 
     const playerCount = Object.keys(clients).length;
     // Support explicit solo practice mode (allow when at least 1 player exists)
@@ -337,13 +397,19 @@ ioServer.on("connection", (client) => {
       gameState.isActive = true;
       gameState.mode = gameData.mode;
       gameState.startTime = Date.now();
+      scores = {};
 
       // Pick random 'it' player
       const playerIds = Object.keys(clients);
       gameState.itPlayerId =
         playerIds[Math.floor(Math.random() * playerIds.length)];
 
-      console.log(`Game started! ${gameState.itPlayerId} is IT!`);
+      logger.gameStarted({
+        mode: gameState.mode,
+        itPlayerId: gameState.itPlayerId,
+        playerCount,
+        requestedBy: client.id,
+      });
 
       // Broadcast game start to all clients
       ioServer.sockets.emit("game-start", {
@@ -352,6 +418,11 @@ ioServer.on("connection", (client) => {
         startTime: gameState.startTime,
       });
     } else {
+      logger.warn("game.start_rejected", {
+        playerId: client.id,
+        playerCount,
+        reason: "insufficient_players",
+      });
       client.emit("game-error", {
         message: "Need at least 2 players to start",
       });
@@ -360,43 +431,65 @@ ioServer.on("connection", (client) => {
 
   // Handle player tagging
   client.on("player-tagged", (data) => {
-    console.log(`Tag attempt: ${data.taggerId} -> ${data.taggedId}`);
+    const taggerId = data?.taggerId;
+    const taggedId = data?.taggedId;
 
-    if (
-      gameState.isActive &&
-      gameState.mode === "tag" &&
-      data.taggerId === gameState.itPlayerId
-    ) {
-      // Verify both players exist
-      if (clients[data.taggerId] && clients[data.taggedId]) {
-        gameState.itPlayerId = data.taggedId;
-        console.log(`Tag successful! ${data.taggedId} is now IT!`);
-
-        // Broadcast to all clients
-        ioServer.sockets.emit("player-tagged", data);
-      }
+    if (!gameState.isActive || gameState.mode !== "tag") {
+      logger.tagRejected({ taggerId, taggedId, reason: "no_active_tag_game" });
+      return;
     }
+
+    if (taggerId !== gameState.itPlayerId) {
+      logger.tagRejected({ taggerId, taggedId, reason: "tagger_not_it" });
+      return;
+    }
+
+    if (!clients[taggerId] || !clients[taggedId]) {
+      logger.tagRejected({ taggerId, taggedId, reason: "unknown_player" });
+      return;
+    }
+
+    gameState.itPlayerId = taggedId;
+    awardScore(taggerId, 1, "tag");
+
+    logger.playerTagged({ taggerId, taggedId, mode: gameState.mode });
+
+    // Broadcast to all clients. `scores` is additive — existing clients ignore it.
+    ioServer.sockets.emit("player-tagged", { ...data, scores });
   });
 
   // Handle game end
   client.on("game-end", () => {
-    console.log(`Game end requested by ${client.id}`);
+    const durationMs = gameState.startTime
+      ? Date.now() - gameState.startTime
+      : null;
+
+    logger.gameEnded({
+      mode: gameState.mode,
+      durationMs,
+      playerCount: Object.keys(clients).length,
+      requestedBy: client.id,
+      finalScores: scores,
+    });
 
     gameState.isActive = false;
     gameState.mode = "none";
     gameState.itPlayerId = null;
     gameState.startTime = null;
+    scores = {};
 
     ioServer.sockets.emit("game-end");
   });
 
   client.on("disconnect", () => {
-    console.log(
-      `User ${client.id} disconnected, there are currently ${ioServer.engine.clientsCount} users connected`,
-    );
-
     // Delete their client from the object
     delete clients[client.id];
+
+    logger.playerDisconnected({
+      playerId: client.id,
+      activePlayers: Object.keys(clients).length,
+      wasIt: gameState.itPlayerId === client.id,
+    });
 
     // Clean up rate limit tracking for this client
     const keysToDelete = [];
@@ -410,3 +503,32 @@ ioServer.on("connection", (client) => {
     ioServer.sockets.emit("move", clients);
   });
 });
+
+/**
+ * Graceful shutdown: stop accepting new connections, close open sockets, and
+ * clear timers so the process can exit cleanly when the platform sends SIGTERM
+ * (Render/Docker deploy or scale-down).
+ *
+ * @param {string} signal - The signal that triggered shutdown.
+ */
+const shutdown = (signal) => {
+  logger.info(GAME_EVENTS.SERVER_SHUTDOWN, {
+    signal,
+    activePlayers: ioServer ? ioServer.engine.clientsCount : 0,
+    uptimeSeconds: Math.floor((Date.now() - SERVER_STARTED_AT) / 1000),
+  });
+
+  clearInterval(rateLimitCleanupTimer);
+
+  ioServer.close(() => {
+    server.close(() => {
+      process.exit(0);
+    });
+  });
+
+  // Failsafe: force exit if connections do not drain within 10 seconds.
+  setTimeout(() => process.exit(0), 10000).unref();
+};
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));

--- a/server/index.js
+++ b/server/index.js
@@ -15,10 +15,10 @@ import {
   CORS_ERROR_CODE,
 } from "./cors.js";
 import { buildHealthReport, healthStatusCode } from "./health.js";
+import { authorizeTag } from "./tagAuthorization.js";
+import { resolvePort } from "./port.js";
 
-// Environment configuration
-const PORT = process.env.PORT ? Number(process.env.PORT) : 4444;
-const ALLOWED_ORIGINS = parseAllowedOrigins(process.env.ALLOWED_ORIGINS);
+const PORT = resolvePort(process.env.PORT);
 const SERVER_STARTED_AT = Date.now();
 const APP_VERSION = process.env.APP_VERSION || null;
 
@@ -28,6 +28,15 @@ const logger = createLogger({
   level: process.env.LOG_LEVEL,
   base: { service: "darkmoon-server" },
 });
+
+// A bare `*` in ALLOWED_ORIGINS is dropped by parseAllowedOrigins (see cors.js
+// for why); log it so a misconfigured deploy is visible instead of silently
+// falling back to the default allow-list.
+const ALLOWED_ORIGINS = parseAllowedOrigins(
+  process.env.ALLOWED_ORIGINS,
+  ({ entry }) =>
+    logger.warn(GAME_EVENTS.CORS_UNSAFE_WILDCARD_DROPPED, { entry }),
+);
 
 // Rate limiting configuration. Limits are applied per-client within a time
 // window (see checkRateLimit windowMs parameter). The default window used by
@@ -431,21 +440,15 @@ ioServer.on("connection", (client) => {
 
   // Handle player tagging
   client.on("player-tagged", (data) => {
-    const taggerId = data?.taggerId;
+    // The actor is the sending socket, never the payload. Trusting
+    // data.taggerId would let any connected client impersonate the IT player,
+    // reassign `itPlayerId`, and award points to someone else.
+    const taggerId = client.id;
     const taggedId = data?.taggedId;
 
-    if (!gameState.isActive || gameState.mode !== "tag") {
-      logger.tagRejected({ taggerId, taggedId, reason: "no_active_tag_game" });
-      return;
-    }
-
-    if (taggerId !== gameState.itPlayerId) {
-      logger.tagRejected({ taggerId, taggedId, reason: "tagger_not_it" });
-      return;
-    }
-
-    if (!clients[taggerId] || !clients[taggedId]) {
-      logger.tagRejected({ taggerId, taggedId, reason: "unknown_player" });
+    const decision = authorizeTag({ taggerId, taggedId, gameState, clients });
+    if (!decision.ok) {
+      logger.tagRejected({ taggerId, taggedId, reason: decision.reason });
       return;
     }
 
@@ -454,8 +457,15 @@ ioServer.on("connection", (client) => {
 
     logger.playerTagged({ taggerId, taggedId, mode: gameState.mode });
 
-    // Broadcast to all clients. `scores` is additive — existing clients ignore it.
-    ioServer.sockets.emit("player-tagged", { ...data, scores });
+    // Broadcast to all clients. `scores` is additive — existing clients ignore
+    // it. taggerId is overridden with the authenticated actor so a spoofed
+    // payload value is never relayed onward.
+    ioServer.sockets.emit("player-tagged", {
+      ...data,
+      taggerId,
+      taggedId,
+      scores,
+    });
   });
 
   // Handle game end

--- a/server/logger.d.ts
+++ b/server/logger.d.ts
@@ -1,6 +1,8 @@
 export type LogLevelName = "debug" | "info" | "warn" | "error" | "silent";
 
-export type LogContext = Record<string, unknown>;
+export interface LogContext {
+  [key: string]: unknown;
+}
 export type LogRecord = Record<string, unknown> & {
   timestamp: string;
   level: string;
@@ -23,6 +25,7 @@ export const GAME_EVENTS: {
   RATE_LIMITED: string;
   VALIDATION_FAILED: string;
   CORS_REJECTED: string;
+  CORS_UNSAFE_WILDCARD_DROPPED: string;
 };
 
 export function resolveLevel(level: string | undefined | null): number;

--- a/server/logger.d.ts
+++ b/server/logger.d.ts
@@ -1,0 +1,95 @@
+export type LogLevelName = "debug" | "info" | "warn" | "error" | "silent";
+
+export type LogContext = Record<string, unknown>;
+export type LogRecord = Record<string, unknown> & {
+  timestamp: string;
+  level: string;
+  event: string;
+};
+
+export const LOG_LEVELS: Record<string, number>;
+export const DEFAULT_LOG_LEVEL: string;
+export const GAME_EVENTS: {
+  SERVER_STARTED: string;
+  SERVER_SHUTDOWN: string;
+  PLAYER_CONNECTED: string;
+  PLAYER_DISCONNECTED: string;
+  PLAYER_TAGGED: string;
+  TAG_REJECTED: string;
+  SCORE_CHANGED: string;
+  GAME_STARTED: string;
+  GAME_ENDED: string;
+  CHAT_MESSAGE: string;
+  RATE_LIMITED: string;
+  VALIDATION_FAILED: string;
+  CORS_REJECTED: string;
+};
+
+export function resolveLevel(level: string | undefined | null): number;
+export function buildRecord(
+  level: string,
+  event: string,
+  context?: LogContext,
+  now?: () => string,
+): LogRecord;
+export function serializeRecord(record: LogRecord): string;
+
+export interface Logger {
+  isLevelEnabled(level: string): boolean;
+  log(level: string, event: string, context?: LogContext): LogRecord | null;
+  debug(event: string, context?: LogContext): LogRecord | null;
+  info(event: string, context?: LogContext): LogRecord | null;
+  warn(event: string, context?: LogContext): LogRecord | null;
+  error(event: string, context?: LogContext): LogRecord | null;
+  child(extraBase?: LogContext): Logger;
+  playerConnected(data: {
+    playerId: string;
+    activePlayers: number;
+  }): LogRecord | null;
+  playerDisconnected(data: {
+    playerId: string;
+    activePlayers: number;
+    wasIt?: boolean;
+  }): LogRecord | null;
+  playerTagged(data: {
+    taggerId: string;
+    taggedId: string;
+    mode?: string;
+  }): LogRecord | null;
+  tagRejected(data: {
+    taggerId: string;
+    taggedId: string;
+    reason: string;
+  }): LogRecord | null;
+  scoreChanged(data: {
+    playerId: string;
+    previousScore: number;
+    newScore: number;
+    reason?: string;
+  }): LogRecord | null;
+  gameStarted(data: {
+    mode: string;
+    itPlayerId?: string | null;
+    playerCount: number;
+  }): LogRecord | null;
+  gameEnded(data: {
+    mode?: string;
+    durationMs?: number | null;
+    playerCount?: number;
+  }): LogRecord | null;
+}
+
+export function createLogger(options?: {
+  level?: string;
+  write?: (line: string) => void;
+  base?: LogContext;
+  now?: () => string;
+}): Logger;
+
+declare const _default: {
+  createLogger: typeof createLogger;
+  LOG_LEVELS: typeof LOG_LEVELS;
+  GAME_EVENTS: typeof GAME_EVENTS;
+  buildRecord: typeof buildRecord;
+};
+export default _default;

--- a/server/logger.js
+++ b/server/logger.js
@@ -1,0 +1,218 @@
+/**
+ * Structured JSON logging for the multiplayer server.
+ *
+ * Every record is a single line of JSON so that log aggregators (Render,
+ * Datadog, `jq`) can index fields without regex-parsing prose. Human-readable
+ * strings are deliberately *not* emitted: the `event` field is the stable
+ * machine-readable key, and any extra context goes in sibling fields.
+ *
+ * Record shape:
+ * ```json
+ * {"timestamp":"2026-08-27T12:00:00.000Z","level":"info","event":"player.connected","playerId":"abc","activePlayers":3}
+ * ```
+ */
+
+/**
+ * Log levels in ascending severity. A logger emits a record only when the
+ * record's level is at or above the configured threshold.
+ * @type {Record<string, number>}
+ */
+export const LOG_LEVELS = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+  silent: 100,
+};
+
+/** @type {string} */
+export const DEFAULT_LOG_LEVEL = "info";
+
+/**
+ * Stable event names for the game lifecycle. Using constants keeps the emitted
+ * keys consistent between the server and the tests/dashboards that assert on
+ * them.
+ */
+export const GAME_EVENTS = {
+  SERVER_STARTED: "server.started",
+  SERVER_SHUTDOWN: "server.shutdown",
+  PLAYER_CONNECTED: "player.connected",
+  PLAYER_DISCONNECTED: "player.disconnected",
+  PLAYER_TAGGED: "game.player_tagged",
+  TAG_REJECTED: "game.tag_rejected",
+  SCORE_CHANGED: "game.score_changed",
+  GAME_STARTED: "game.started",
+  GAME_ENDED: "game.ended",
+  CHAT_MESSAGE: "chat.message",
+  RATE_LIMITED: "security.rate_limited",
+  VALIDATION_FAILED: "security.validation_failed",
+  CORS_REJECTED: "security.cors_rejected",
+};
+
+/**
+ * Resolve a configured level name into a numeric threshold.
+ *
+ * @param {string | undefined | null} level - Level name, case-insensitive.
+ * @returns {number} Numeric threshold, falling back to {@link DEFAULT_LOG_LEVEL}.
+ */
+export const resolveLevel = (level) => {
+  if (typeof level !== "string") return LOG_LEVELS[DEFAULT_LOG_LEVEL];
+
+  const normalized = level.trim().toLowerCase();
+  return LOG_LEVELS[normalized] ?? LOG_LEVELS[DEFAULT_LOG_LEVEL];
+};
+
+/**
+ * Build a log record without emitting it. Exported so tests can assert on the
+ * exact serialized shape independently of transport.
+ *
+ * Reserved keys (`timestamp`, `level`, `event`) always win over caller-supplied
+ * context so a stray `level` field in game data cannot corrupt the record.
+ *
+ * @param {string} level - Level name.
+ * @param {string} event - Stable event key, e.g. `player.connected`.
+ * @param {Record<string, unknown>} [context] - Extra structured fields.
+ * @param {() => string} [now] - Timestamp factory, injectable for tests.
+ * @returns {Record<string, unknown>} The record object.
+ */
+export const buildRecord = (level, event, context = {}, now) => {
+  const timestamp =
+    typeof now === "function" ? now() : new Date().toISOString();
+
+  const safeContext =
+    context && typeof context === "object" && !Array.isArray(context)
+      ? context
+      : {};
+
+  return { ...safeContext, timestamp, level, event };
+};
+
+/**
+ * Serialize a record to a single JSON line.
+ *
+ * Falls back to a minimal error record when the context contains circular
+ * references or otherwise unserializable values, so a logging failure can never
+ * crash a game event handler.
+ *
+ * @param {Record<string, unknown>} record - Record from {@link buildRecord}.
+ * @returns {string} JSON line.
+ */
+export const serializeRecord = (record) => {
+  try {
+    return JSON.stringify(record);
+  } catch {
+    return JSON.stringify({
+      timestamp: record?.timestamp ?? new Date().toISOString(),
+      level: record?.level ?? "error",
+      event: record?.event ?? "logger.serialize_failed",
+      serializationError: true,
+    });
+  }
+};
+
+/**
+ * Create a structured logger.
+ *
+ * @param {object} [options]
+ * @param {string} [options.level] - Minimum level to emit (default `info`,
+ *   overridable via the `LOG_LEVEL` env var by the caller).
+ * @param {(line: string) => void} [options.write] - Transport for emitted
+ *   lines. Defaults to `console.log`; injectable so tests capture output.
+ * @param {Record<string, unknown>} [options.base] - Fields merged into every
+ *   record (e.g. `{ service: "darkmoon-server" }`).
+ * @param {() => string} [options.now] - Timestamp factory, injectable for tests.
+ * @returns {object} Logger with `debug`/`info`/`warn`/`error`, `log`,
+ *   `isLevelEnabled`, `child`, and the game-event helpers.
+ */
+export const createLogger = (options = {}) => {
+  const { level = DEFAULT_LOG_LEVEL, write, base = {}, now } = options;
+
+  const threshold = resolveLevel(level);
+  const emit =
+    typeof write === "function" ? write : (line) => console.log(line);
+
+  /**
+   * @param {string} recordLevel
+   * @returns {boolean}
+   */
+  const isLevelEnabled = (recordLevel) =>
+    resolveLevel(recordLevel) >= threshold;
+
+  /**
+   * @param {string} recordLevel
+   * @param {string} event
+   * @param {Record<string, unknown>} [context]
+   * @returns {Record<string, unknown> | null} The emitted record, or null when
+   *   suppressed by the level threshold.
+   */
+  const log = (recordLevel, event, context = {}) => {
+    if (!isLevelEnabled(recordLevel)) return null;
+
+    const record = buildRecord(
+      recordLevel,
+      event,
+      { ...base, ...context },
+      now,
+    );
+    emit(serializeRecord(record));
+    return record;
+  };
+
+  const logger = {
+    isLevelEnabled,
+    log,
+    debug: (event, context) => log("debug", event, context),
+    info: (event, context) => log("info", event, context),
+    warn: (event, context) => log("warn", event, context),
+    error: (event, context) => log("error", event, context),
+
+    /**
+     * Derive a logger that carries additional permanent fields.
+     * @param {Record<string, unknown>} extraBase
+     */
+    child: (extraBase = {}) =>
+      createLogger({
+        level,
+        write: emit,
+        base: { ...base, ...extraBase },
+        now,
+      }),
+
+    // ---- Game event helpers -------------------------------------------------
+    // These exist so the call sites in index.js cannot drift on field naming.
+
+    /** @param {{ playerId: string, activePlayers: number }} data */
+    playerConnected: (data) => log("info", GAME_EVENTS.PLAYER_CONNECTED, data),
+
+    /** @param {{ playerId: string, activePlayers: number, wasIt?: boolean }} data */
+    playerDisconnected: (data) =>
+      log("info", GAME_EVENTS.PLAYER_DISCONNECTED, data),
+
+    /** @param {{ taggerId: string, taggedId: string, mode?: string }} data */
+    playerTagged: (data) => log("info", GAME_EVENTS.PLAYER_TAGGED, data),
+
+    /** @param {{ taggerId: string, taggedId: string, reason: string }} data */
+    tagRejected: (data) => log("warn", GAME_EVENTS.TAG_REJECTED, data),
+
+    /** @param {{ playerId: string, previousScore: number, newScore: number, reason?: string }} data */
+    scoreChanged: (data) =>
+      log("info", GAME_EVENTS.SCORE_CHANGED, {
+        ...data,
+        delta:
+          typeof data?.newScore === "number" &&
+          typeof data?.previousScore === "number"
+            ? data.newScore - data.previousScore
+            : undefined,
+      }),
+
+    /** @param {{ mode: string, itPlayerId?: string | null, playerCount: number }} data */
+    gameStarted: (data) => log("info", GAME_EVENTS.GAME_STARTED, data),
+
+    /** @param {{ mode?: string, durationMs?: number | null, playerCount?: number }} data */
+    gameEnded: (data) => log("info", GAME_EVENTS.GAME_ENDED, data),
+  };
+
+  return logger;
+};
+
+export default { createLogger, LOG_LEVELS, GAME_EVENTS, buildRecord };

--- a/server/logger.js
+++ b/server/logger.js
@@ -47,6 +47,7 @@ export const GAME_EVENTS = {
   RATE_LIMITED: "security.rate_limited",
   VALIDATION_FAILED: "security.validation_failed",
   CORS_REJECTED: "security.cors_rejected",
+  CORS_UNSAFE_WILDCARD_DROPPED: "security.cors_unsafe_wildcard_dropped",
 };
 
 /**
@@ -148,10 +149,13 @@ export const createLogger = (options = {}) => {
   const log = (recordLevel, event, context = {}) => {
     if (!isLevelEnabled(recordLevel)) return null;
 
+    // Base wins over per-record context: child() documents its fields as
+    // permanent, so a call-site key must not silently reattribute a record
+    // (e.g. a stray `playerId` overwriting the child's bound one).
     const record = buildRecord(
       recordLevel,
       event,
-      { ...base, ...context },
+      { ...context, ...base },
       now,
     );
     emit(serializeRecord(record));

--- a/server/port.d.ts
+++ b/server/port.d.ts
@@ -1,0 +1,8 @@
+export const DEFAULT_PORT: number;
+export function resolvePort(raw: string | undefined): number;
+
+declare const _default: {
+  DEFAULT_PORT: typeof DEFAULT_PORT;
+  resolvePort: typeof resolvePort;
+};
+export default _default;

--- a/server/port.js
+++ b/server/port.js
@@ -1,0 +1,32 @@
+/**
+ * PORT validation, split out from `server/index.js` so it is unit-testable
+ * without booting a real server (index.js calls `app.listen` at import time).
+ */
+
+/** @type {number} */
+export const DEFAULT_PORT = 4444;
+
+/**
+ * Parse and validate the configured port.
+ *
+ * An unset/empty value falls back to {@link DEFAULT_PORT}. Anything else must
+ * be an integer in 1–65535 — `PORT=abc` would otherwise reach
+ * `app.listen(NaN)` and fail with no indication that configuration was the
+ * cause.
+ *
+ * @param {string | undefined} raw - Raw `process.env.PORT`.
+ * @returns {number} A valid port number.
+ * @throws {Error} When the value is set but not a valid port.
+ */
+export const resolvePort = (raw) => {
+  if (raw === undefined || raw === "") return DEFAULT_PORT;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    throw new Error(
+      `Invalid PORT "${raw}": expected an integer between 1 and 65535.`,
+    );
+  }
+  return parsed;
+};
+
+export default { DEFAULT_PORT, resolvePort };

--- a/server/tagAuthorization.d.ts
+++ b/server/tagAuthorization.d.ts
@@ -1,0 +1,20 @@
+export interface TagGameState {
+  isActive?: boolean;
+  mode?: string;
+  itPlayerId?: string | null;
+}
+
+export type TagAuthorizationDecision =
+  { ok: true } | { ok: false; reason: string };
+
+export function authorizeTag(params: {
+  taggerId: string;
+  taggedId: unknown;
+  gameState: TagGameState | null | undefined;
+  clients: Record<string, unknown> | null | undefined;
+}): TagAuthorizationDecision;
+
+declare const _default: {
+  authorizeTag: typeof authorizeTag;
+};
+export default _default;

--- a/server/tagAuthorization.js
+++ b/server/tagAuthorization.js
@@ -1,0 +1,51 @@
+/**
+ * Pure authorization decision for the `player-tagged` socket event.
+ *
+ * Split out from `server/index.js` so the impersonation/self-tag/unknown-player
+ * rules are unit-testable without booting a real Socket.io server (index.js
+ * calls `app.listen` at import time, so it cannot be imported in a test).
+ *
+ * The caller is responsible for binding `taggerId` to the sending socket's
+ * `client.id` — this function never trusts a client-supplied tagger identity.
+ */
+
+/**
+ * @param {object} params
+ * @param {string} params.taggerId - Authenticated actor (`client.id`), never
+ *   a client-supplied value.
+ * @param {unknown} params.taggedId - Client-supplied target player id.
+ * @param {{ isActive?: boolean, mode?: string, itPlayerId?: string | null } | null | undefined} params.gameState
+ * @param {Record<string, unknown> | null | undefined} params.clients - Tracked
+ *   client map, used for own-property-safe existence checks so an id like
+ *   `"__proto__"` cannot resolve truthy against `Object.prototype`.
+ * @returns {{ ok: true } | { ok: false, reason: string }}
+ */
+export const authorizeTag = ({ taggerId, taggedId, gameState, clients }) => {
+  if (!gameState?.isActive || gameState?.mode !== "tag") {
+    return { ok: false, reason: "no_active_tag_game" };
+  }
+
+  if (taggerId !== gameState.itPlayerId) {
+    return { ok: false, reason: "tagger_not_it" };
+  }
+
+  // Self-tagging would hand IT back to the tagger and award a point on every
+  // emit — an unbounded score farm.
+  if (taggedId === taggerId) {
+    return { ok: false, reason: "self_tag" };
+  }
+
+  const isKnownPlayer = (id) =>
+    typeof id === "string" &&
+    clients != null &&
+    typeof clients === "object" &&
+    Object.prototype.hasOwnProperty.call(clients, id);
+
+  if (!isKnownPlayer(taggerId) || !isKnownPlayer(taggedId)) {
+    return { ok: false, reason: "unknown_player" };
+  }
+
+  return { ok: true };
+};
+
+export default { authorizeTag };

--- a/src/__tests__/server.cors.test.ts
+++ b/src/__tests__/server.cors.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  DEFAULT_ALLOWED_ORIGINS,
+  parseAllowedOrigins,
+  matchesOrigin,
+  isOriginAllowed,
+  createOriginCallback,
+  createCorsOptions,
+  createCorsError,
+  CORS_ERROR_CODE,
+} from "../../server/cors.js";
+
+describe("server CORS policy", () => {
+  describe("parseAllowedOrigins", () => {
+    it("falls back to defaults when the env var is unset", () => {
+      expect(parseAllowedOrigins(undefined)).toEqual(DEFAULT_ALLOWED_ORIGINS);
+      expect(parseAllowedOrigins(null)).toEqual(DEFAULT_ALLOWED_ORIGINS);
+    });
+
+    it("falls back to defaults when the env var is empty or only separators", () => {
+      expect(parseAllowedOrigins("")).toEqual(DEFAULT_ALLOWED_ORIGINS);
+      expect(parseAllowedOrigins("  ,  , ")).toEqual(DEFAULT_ALLOWED_ORIGINS);
+    });
+
+    it("splits and trims a comma-separated list", () => {
+      expect(
+        parseAllowedOrigins("https://a.example, https://b.example"),
+      ).toEqual(["https://a.example", "https://b.example"]);
+    });
+
+    it("does not mutate the shared defaults array", () => {
+      const first = parseAllowedOrigins(undefined);
+      first.push("https://evil.example");
+      expect(parseAllowedOrigins(undefined)).toEqual(DEFAULT_ALLOWED_ORIGINS);
+      expect(DEFAULT_ALLOWED_ORIGINS).not.toContain("https://evil.example");
+    });
+  });
+
+  describe("matchesOrigin", () => {
+    it("matches an exact origin", () => {
+      expect(
+        matchesOrigin(
+          "https://darkmoon-dev.netlify.app",
+          "https://darkmoon-dev.netlify.app",
+        ),
+      ).toBe(true);
+    });
+
+    it("rejects a different origin", () => {
+      expect(
+        matchesOrigin(
+          "https://evil.example",
+          "https://darkmoon-dev.netlify.app",
+        ),
+      ).toBe(false);
+    });
+
+    it("expands * as a wildcard for deploy previews", () => {
+      const pattern = "https://deploy-preview-*--darkmoon-dev.netlify.app";
+      expect(
+        matchesOrigin(
+          "https://deploy-preview-321--darkmoon-dev.netlify.app",
+          pattern,
+        ),
+      ).toBe(true);
+      expect(
+        matchesOrigin(
+          "https://deploy-preview-9--darkmoon-dev.netlify.app",
+          pattern,
+        ),
+      ).toBe(true);
+    });
+
+    it("treats dots literally so look-alike hosts are rejected", () => {
+      // Regression guard: an unescaped `.` in the pattern would let this pass.
+      expect(
+        matchesOrigin(
+          "https://darkmoon-devXnetlify.app",
+          "https://darkmoon-dev.netlify.app",
+        ),
+      ).toBe(false);
+      expect(
+        matchesOrigin(
+          "https://darkmoon-dev-netlify-app",
+          "https://darkmoon-dev.netlify.app",
+        ),
+      ).toBe(false);
+    });
+
+    it("anchors the pattern at both ends", () => {
+      expect(
+        matchesOrigin(
+          "https://darkmoon-dev.netlify.app.evil.example",
+          "https://darkmoon-dev.netlify.app",
+        ),
+      ).toBe(false);
+      expect(
+        matchesOrigin(
+          "https://evil.example/https://darkmoon-dev.netlify.app",
+          "https://darkmoon-dev.netlify.app",
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false for non-string inputs", () => {
+      expect(matchesOrigin(undefined as unknown as string, "https://a")).toBe(
+        false,
+      );
+      expect(matchesOrigin("https://a", undefined as unknown as string)).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("isOriginAllowed", () => {
+    const allowed = [
+      "http://localhost:3000",
+      "https://deploy-preview-*--darkmoon-dev.netlify.app",
+      "https://darkmoon-dev.netlify.app",
+    ];
+
+    it("allows a configured origin", () => {
+      expect(isOriginAllowed("http://localhost:3000", allowed)).toBe(true);
+      expect(isOriginAllowed("https://darkmoon-dev.netlify.app", allowed)).toBe(
+        true,
+      );
+    });
+
+    it("allows a wildcard deploy preview", () => {
+      expect(
+        isOriginAllowed(
+          "https://deploy-preview-42--darkmoon-dev.netlify.app",
+          allowed,
+        ),
+      ).toBe(true);
+    });
+
+    it("rejects an unlisted origin", () => {
+      expect(isOriginAllowed("https://evil.example", allowed)).toBe(false);
+      expect(isOriginAllowed("http://localhost:9999", allowed)).toBe(false);
+    });
+
+    it("allows requests with no origin (curl, health checks, native clients)", () => {
+      expect(isOriginAllowed(undefined, allowed)).toBe(true);
+      expect(isOriginAllowed("", allowed)).toBe(true);
+      expect(isOriginAllowed(null, allowed)).toBe(true);
+    });
+
+    it("rejects when the allow-list is not an array", () => {
+      expect(
+        isOriginAllowed("https://a.example", undefined as unknown as string[]),
+      ).toBe(false);
+    });
+  });
+
+  describe("createOriginCallback", () => {
+    const allowed = ["https://darkmoon-dev.netlify.app"];
+
+    it("calls back with (null, true) for an allowed origin", () => {
+      const callback = vi.fn();
+      createOriginCallback(allowed)(
+        "https://darkmoon-dev.netlify.app",
+        callback,
+      );
+      expect(callback).toHaveBeenCalledWith(null, true);
+    });
+
+    it("calls back with an error for a rejected origin", () => {
+      const callback = vi.fn();
+      createOriginCallback(allowed)("https://evil.example", callback);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      const [error, allow] = callback.mock.calls[0];
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("Not allowed by CORS");
+      expect(allow).toBeUndefined();
+    });
+
+    it("invokes the rejection hook exactly once with the offending origin", () => {
+      const onRejected = vi.fn();
+      const callback = vi.fn();
+      createOriginCallback(allowed, onRejected)(
+        "https://evil.example",
+        callback,
+      );
+
+      expect(onRejected).toHaveBeenCalledTimes(1);
+      expect(onRejected).toHaveBeenCalledWith({
+        origin: "https://evil.example",
+      });
+    });
+
+    it("does not invoke the rejection hook for an allowed origin", () => {
+      const onRejected = vi.fn();
+      createOriginCallback(allowed, onRejected)(
+        "https://darkmoon-dev.netlify.app",
+        vi.fn(),
+      );
+      expect(onRejected).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("createCorsError", () => {
+    it("is tagged so the error handler can answer 403 instead of 500", () => {
+      const error = createCorsError();
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.code).toBe(CORS_ERROR_CODE);
+      expect(error.statusCode).toBe(403);
+    });
+
+    it("is the error handed to a rejected origin callback", () => {
+      const callback = vi.fn();
+      createOriginCallback(["https://darkmoon-dev.netlify.app"])(
+        "https://evil.example",
+        callback,
+      );
+
+      expect(callback.mock.calls[0][0]).toMatchObject({
+        code: CORS_ERROR_CODE,
+        statusCode: 403,
+      });
+    });
+  });
+
+  describe("createCorsOptions", () => {
+    it("exposes the shared HTTP + WebSocket policy", () => {
+      const options = createCorsOptions(["https://darkmoon-dev.netlify.app"]);
+
+      expect(options.methods).toEqual(["GET", "POST"]);
+      expect(options.credentials).toBe(true);
+      expect(typeof options.origin).toBe("function");
+    });
+
+    it("produces an origin function honouring the allow-list", () => {
+      const options = createCorsOptions(["https://darkmoon-dev.netlify.app"]);
+      const allowCallback = vi.fn();
+      const denyCallback = vi.fn();
+
+      options.origin("https://darkmoon-dev.netlify.app", allowCallback);
+      options.origin("https://evil.example", denyCallback);
+
+      expect(allowCallback).toHaveBeenCalledWith(null, true);
+      expect(denyCallback.mock.calls[0][0]).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/src/__tests__/server.cors.test.ts
+++ b/src/__tests__/server.cors.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import {
   DEFAULT_ALLOWED_ORIGINS,
   parseAllowedOrigins,
+  isUnsafeWildcard,
   matchesOrigin,
   isOriginAllowed,
   createOriginCallback,
@@ -33,6 +34,45 @@ describe("server CORS policy", () => {
       first.push("https://evil.example");
       expect(parseAllowedOrigins(undefined)).toEqual(DEFAULT_ALLOWED_ORIGINS);
       expect(DEFAULT_ALLOWED_ORIGINS).not.toContain("https://evil.example");
+    });
+
+    it("drops a bare wildcard entry instead of allowing every origin under credentials: true", () => {
+      // createCorsOptions always sets credentials: true, so a literal "*"
+      // reaching the allow-list would let any site make authenticated
+      // cross-site requests (CWE-942).
+      expect(parseAllowedOrigins("*")).toEqual(DEFAULT_ALLOWED_ORIGINS);
+    });
+
+    it("drops a bare wildcard mixed in with real origins, keeping the rest", () => {
+      expect(
+        parseAllowedOrigins("https://a.example, *, https://b.example"),
+      ).toEqual(["https://a.example", "https://b.example"]);
+    });
+
+    it("keeps a scoped wildcard like the deploy-preview pattern", () => {
+      const scoped = "https://deploy-preview-*--darkmoon-dev.netlify.app";
+      expect(parseAllowedOrigins(scoped)).toEqual([scoped]);
+    });
+
+    it("reports the dropped entry via the onUnsafeWildcard hook", () => {
+      const onUnsafeWildcard = vi.fn();
+      parseAllowedOrigins("https://a.example, *", onUnsafeWildcard);
+
+      expect(onUnsafeWildcard).toHaveBeenCalledTimes(1);
+      expect(onUnsafeWildcard).toHaveBeenCalledWith({ entry: "*" });
+    });
+  });
+
+  describe("isUnsafeWildcard", () => {
+    it("flags a bare wildcard", () => {
+      expect(isUnsafeWildcard("*")).toBe(true);
+    });
+
+    it("does not flag a scoped wildcard or a normal origin", () => {
+      expect(
+        isUnsafeWildcard("https://deploy-preview-*--darkmoon-dev.netlify.app"),
+      ).toBe(false);
+      expect(isUnsafeWildcard("https://darkmoon-dev.netlify.app")).toBe(false);
     });
   });
 

--- a/src/__tests__/server.cors.test.ts
+++ b/src/__tests__/server.cors.test.ts
@@ -111,6 +111,19 @@ describe("server CORS policy", () => {
       ).toBe(true);
     });
 
+    it("scopes the wildcard to a single DNS label so it cannot absorb extra subdomains", () => {
+      // Regression guard: a cross-label wildcard (.*) would let an attacker
+      // splice extra, attacker-controlled subdomains into the wildcard slot
+      // of a deploy-preview pattern.
+      const pattern = "https://deploy-preview-*--darkmoon-dev.netlify.app";
+      expect(
+        matchesOrigin(
+          "https://deploy-preview-1.attacker.example--darkmoon-dev.netlify.app",
+          pattern,
+        ),
+      ).toBe(false);
+    });
+
     it("treats dots literally so look-alike hosts are rejected", () => {
       // Regression guard: an unescaped `.` in the pattern would let this pass.
       expect(

--- a/src/__tests__/server.health.test.ts
+++ b/src/__tests__/server.health.test.ts
@@ -133,6 +133,35 @@ describe("server health endpoint payload", () => {
       );
     });
 
+    it("falls back to the default capacity for a non-finite maxPlayers", () => {
+      const report = buildHealthReport({
+        connections: 3,
+        maxPlayers: NaN,
+        now: NOW,
+      });
+
+      expect(report.maxPlayers).toBe(DEFAULT_MAX_PLAYERS);
+      expect(report.status).toBe(STATUS_OK);
+    });
+
+    it("falls back to the default capacity for a negative maxPlayers instead of pinning degraded forever", () => {
+      const report = buildHealthReport({
+        connections: 0,
+        maxPlayers: -5,
+        now: NOW,
+      });
+
+      expect(report.maxPlayers).toBe(DEFAULT_MAX_PLAYERS);
+      expect(report.status).toBe(STATUS_OK);
+    });
+
+    it("falls back to the default capacity for a non-integer maxPlayers", () => {
+      expect(
+        buildHealthReport({ connections: 1, maxPlayers: 2.5, now: NOW })
+          .maxPlayers,
+      ).toBe(DEFAULT_MAX_PLAYERS);
+    });
+
     it("reports the build version when configured", () => {
       expect(buildHealthReport({ now: NOW, version: "1.4.0" }).version).toBe(
         "1.4.0",

--- a/src/__tests__/server.health.test.ts
+++ b/src/__tests__/server.health.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildHealthReport,
+  countActiveGames,
+  countActivePlayers,
+  healthStatusCode,
+  STATUS_OK,
+  STATUS_DEGRADED,
+  DEFAULT_MAX_PLAYERS,
+} from "../../server/health.js";
+
+const NOW = Date.parse("2026-08-27T12:00:00.000Z");
+
+describe("server health endpoint payload", () => {
+  describe("countActivePlayers", () => {
+    it("prefers the socket engine connection count", () => {
+      expect(countActivePlayers({ connections: 5, clients: { a: {} } })).toBe(
+        5,
+      );
+    });
+
+    it("falls back to the tracked client map", () => {
+      expect(countActivePlayers({ clients: { a: {}, b: {} } })).toBe(2);
+    });
+
+    it("returns 0 when there is no state at all", () => {
+      expect(countActivePlayers()).toBe(0);
+      expect(countActivePlayers({})).toBe(0);
+    });
+
+    it("never reports a negative or non-finite count", () => {
+      expect(countActivePlayers({ connections: -3 })).toBe(0);
+      expect(countActivePlayers({ connections: NaN, clients: { a: {} } })).toBe(
+        1,
+      );
+    });
+  });
+
+  describe("countActiveGames", () => {
+    it("counts an in-progress game", () => {
+      expect(countActiveGames({ isActive: true, mode: "tag" })).toBe(1);
+    });
+
+    it("counts zero when no game is running", () => {
+      expect(countActiveGames({ isActive: false })).toBe(0);
+      expect(countActiveGames(null)).toBe(0);
+      expect(countActiveGames(undefined)).toBe(0);
+    });
+  });
+
+  describe("buildHealthReport", () => {
+    it("reports status, active players, and active games", () => {
+      const report = buildHealthReport({
+        connections: 3,
+        gameState: { isActive: true, mode: "tag", startTime: NOW - 60000 },
+        startedAt: NOW - 120000,
+        now: NOW,
+      });
+
+      expect(report.status).toBe(STATUS_OK);
+      expect(report.activePlayers).toBe(3);
+      expect(report.activeGames).toBe(1);
+    });
+
+    it("reports uptime in whole seconds", () => {
+      const report = buildHealthReport({
+        startedAt: NOW - 90_500,
+        now: NOW,
+      });
+
+      expect(report.uptimeSeconds).toBe(90);
+    });
+
+    it("reports zero uptime when the start time is unknown", () => {
+      expect(buildHealthReport({ now: NOW }).uptimeSeconds).toBe(0);
+    });
+
+    it("never reports negative uptime for a clock skew", () => {
+      expect(
+        buildHealthReport({ startedAt: NOW + 5000, now: NOW }).uptimeSeconds,
+      ).toBe(0);
+    });
+
+    it("includes an ISO timestamp", () => {
+      expect(buildHealthReport({ now: NOW }).timestamp).toBe(
+        "2026-08-27T12:00:00.000Z",
+      );
+    });
+
+    it("describes the current game", () => {
+      const report = buildHealthReport({
+        gameState: { isActive: true, mode: "tag", startTime: NOW - 30000 },
+        now: NOW,
+      });
+
+      expect(report.game).toEqual({
+        isActive: true,
+        mode: "tag",
+        startedAt: "2026-08-27T11:59:30.000Z",
+      });
+    });
+
+    it("reports an idle game with a null start time", () => {
+      const report = buildHealthReport({ now: NOW });
+
+      expect(report.game).toEqual({
+        isActive: false,
+        mode: "none",
+        startedAt: null,
+      });
+    });
+
+    it("reports degraded once capacity is reached", () => {
+      const report = buildHealthReport({
+        connections: 10,
+        maxPlayers: 10,
+        now: NOW,
+      });
+
+      expect(report.status).toBe(STATUS_DEGRADED);
+      expect(report.maxPlayers).toBe(10);
+    });
+
+    it("stays ok just below capacity", () => {
+      expect(
+        buildHealthReport({ connections: 9, maxPlayers: 10, now: NOW }).status,
+      ).toBe(STATUS_OK);
+    });
+
+    it("applies the default capacity when none is supplied", () => {
+      expect(buildHealthReport({ now: NOW }).maxPlayers).toBe(
+        DEFAULT_MAX_PLAYERS,
+      );
+    });
+
+    it("reports the build version when configured", () => {
+      expect(buildHealthReport({ now: NOW, version: "1.4.0" }).version).toBe(
+        "1.4.0",
+      );
+      expect(buildHealthReport({ now: NOW }).version).toBeNull();
+    });
+
+    it("produces a payload with every documented key", () => {
+      const report = buildHealthReport({ now: NOW });
+
+      expect(Object.keys(report).sort()).toEqual(
+        [
+          "activeGames",
+          "activePlayers",
+          "game",
+          "maxPlayers",
+          "status",
+          "timestamp",
+          "uptimeSeconds",
+          "version",
+        ].sort(),
+      );
+    });
+
+    it("is JSON-serializable", () => {
+      const report = buildHealthReport({
+        connections: 2,
+        gameState: { isActive: true, mode: "tag", startTime: NOW },
+        startedAt: NOW - 1000,
+        now: NOW,
+      });
+
+      expect(() => JSON.stringify(report)).not.toThrow();
+      expect(JSON.parse(JSON.stringify(report))).toEqual(report);
+    });
+
+    it("works with no arguments at all", () => {
+      expect(() => buildHealthReport()).not.toThrow();
+      expect(buildHealthReport().activePlayers).toBe(0);
+    });
+  });
+
+  describe("healthStatusCode", () => {
+    it("returns 200 for ok", () => {
+      expect(healthStatusCode({ status: STATUS_OK })).toBe(200);
+    });
+
+    it("returns 200 for degraded so a busy server is not cycled", () => {
+      expect(healthStatusCode({ status: STATUS_DEGRADED })).toBe(200);
+    });
+
+    it("returns 503 when no valid report is available", () => {
+      expect(healthStatusCode({ status: "unknown" })).toBe(503);
+      expect(healthStatusCode({})).toBe(503);
+    });
+  });
+});

--- a/src/__tests__/server.logger.test.ts
+++ b/src/__tests__/server.logger.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import type { Logger, LogContext, LogRecord } from "../../server/logger.d.ts";
 import {
   createLogger,
   buildRecord,
@@ -8,10 +9,25 @@ import {
   GAME_EVENTS,
 } from "../../server/logger.js";
 
+interface CapturingLoggerOptions {
+  level?: string;
+  base?: LogContext;
+  now?: () => string;
+}
+
+interface CapturingLogger {
+  logger: Logger;
+  lines: string[];
+  records: () => LogRecord[];
+  last: () => LogRecord;
+}
+
 /**
  * Build a logger whose output is captured as parsed JSON records.
  */
-const createCapturingLogger = (options: Record<string, unknown> = {}) => {
+const createCapturingLogger = (
+  options: CapturingLoggerOptions = {},
+): CapturingLogger => {
   const lines: string[] = [];
   const logger = createLogger({
     write: (line: string) => lines.push(line),
@@ -174,6 +190,18 @@ describe("server structured logger", () => {
       logger.child({ playerId: "abc" }).info("suppressed");
 
       expect(lines).toHaveLength(0);
+    });
+
+    it("does not let a call-site context field overwrite a bound child field", () => {
+      const { logger, last } = createCapturingLogger({
+        base: { service: "darkmoon-server" },
+      });
+
+      logger.child({ playerId: "abc" }).info("scoped.event", {
+        playerId: "spoofed",
+      });
+
+      expect(last().playerId).toBe("abc");
     });
   });
 

--- a/src/__tests__/server.logger.test.ts
+++ b/src/__tests__/server.logger.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  createLogger,
+  buildRecord,
+  serializeRecord,
+  resolveLevel,
+  LOG_LEVELS,
+  GAME_EVENTS,
+} from "../../server/logger.js";
+
+/**
+ * Build a logger whose output is captured as parsed JSON records.
+ */
+const createCapturingLogger = (options: Record<string, unknown> = {}) => {
+  const lines: string[] = [];
+  const logger = createLogger({
+    write: (line: string) => lines.push(line),
+    now: () => "2026-08-27T12:00:00.000Z",
+    ...options,
+  });
+
+  return {
+    logger,
+    lines,
+    records: () => lines.map((line) => JSON.parse(line)),
+    last: () => JSON.parse(lines[lines.length - 1]),
+  };
+};
+
+describe("server structured logger", () => {
+  describe("level resolution", () => {
+    it("orders levels by ascending severity", () => {
+      expect(LOG_LEVELS.debug).toBeLessThan(LOG_LEVELS.info);
+      expect(LOG_LEVELS.info).toBeLessThan(LOG_LEVELS.warn);
+      expect(LOG_LEVELS.warn).toBeLessThan(LOG_LEVELS.error);
+    });
+
+    it("is case-insensitive and tolerates whitespace", () => {
+      expect(resolveLevel(" WARN ")).toBe(LOG_LEVELS.warn);
+    });
+
+    it("falls back to info for unknown or non-string levels", () => {
+      expect(resolveLevel("nonsense")).toBe(LOG_LEVELS.info);
+      expect(resolveLevel(undefined)).toBe(LOG_LEVELS.info);
+    });
+  });
+
+  describe("record shape", () => {
+    it("emits timestamp, level, and event on every record", () => {
+      const { logger, last } = createCapturingLogger();
+      logger.info("test.event");
+
+      expect(last()).toMatchObject({
+        timestamp: "2026-08-27T12:00:00.000Z",
+        level: "info",
+        event: "test.event",
+      });
+    });
+
+    it("merges context fields into the record", () => {
+      const { logger, last } = createCapturingLogger();
+      logger.info("test.event", { playerId: "abc", activePlayers: 3 });
+
+      expect(last()).toMatchObject({ playerId: "abc", activePlayers: 3 });
+    });
+
+    it("emits one line of valid JSON per call", () => {
+      const { logger, lines } = createCapturingLogger();
+      logger.info("a");
+      logger.warn("b");
+
+      expect(lines).toHaveLength(2);
+      lines.forEach((line) => {
+        expect(line).not.toContain("\n");
+        expect(() => JSON.parse(line)).not.toThrow();
+      });
+    });
+
+    it("does not let context override the reserved keys", () => {
+      const record = buildRecord(
+        "info",
+        "real.event",
+        { level: "error", event: "spoofed", timestamp: "nope" },
+        () => "2026-08-27T12:00:00.000Z",
+      );
+
+      expect(record.level).toBe("info");
+      expect(record.event).toBe("real.event");
+      expect(record.timestamp).toBe("2026-08-27T12:00:00.000Z");
+    });
+
+    it("merges base fields into every record", () => {
+      const { logger, records } = createCapturingLogger({
+        base: { service: "darkmoon-server" },
+      });
+      logger.info("one");
+      logger.error("two");
+
+      records().forEach((record) => {
+        expect(record.service).toBe("darkmoon-server");
+      });
+    });
+
+    it("survives unserializable context instead of throwing", () => {
+      const circular: Record<string, unknown> = { name: "loop" };
+      circular.self = circular;
+
+      const line = serializeRecord({
+        timestamp: "2026-08-27T12:00:00.000Z",
+        level: "info",
+        event: "test.event",
+        circular,
+      });
+
+      const parsed = JSON.parse(line);
+      expect(parsed.serializationError).toBe(true);
+      expect(parsed.event).toBe("test.event");
+    });
+  });
+
+  describe("level filtering", () => {
+    it("suppresses records below the configured threshold", () => {
+      const { logger, lines } = createCapturingLogger({ level: "warn" });
+
+      logger.debug("skipped.debug");
+      logger.info("skipped.info");
+      logger.warn("kept.warn");
+      logger.error("kept.error");
+
+      expect(lines).toHaveLength(2);
+      expect(JSON.parse(lines[0]).event).toBe("kept.warn");
+      expect(JSON.parse(lines[1]).event).toBe("kept.error");
+    });
+
+    it("returns null for a suppressed record and the record when emitted", () => {
+      const { logger } = createCapturingLogger({ level: "warn" });
+
+      expect(logger.info("suppressed")).toBeNull();
+      expect(logger.error("emitted")).toMatchObject({ event: "emitted" });
+    });
+
+    it("emits nothing at the silent level", () => {
+      const { logger, lines } = createCapturingLogger({ level: "silent" });
+
+      logger.error("still.suppressed");
+      expect(lines).toHaveLength(0);
+    });
+
+    it("reports whether a level is enabled", () => {
+      const { logger } = createCapturingLogger({ level: "warn" });
+
+      expect(logger.isLevelEnabled("info")).toBe(false);
+      expect(logger.isLevelEnabled("error")).toBe(true);
+    });
+  });
+
+  describe("child loggers", () => {
+    it("inherits base fields and adds its own", () => {
+      const { logger, last } = createCapturingLogger({
+        base: { service: "darkmoon-server" },
+      });
+
+      logger.child({ playerId: "abc" }).info("scoped.event");
+
+      expect(last()).toMatchObject({
+        service: "darkmoon-server",
+        playerId: "abc",
+        event: "scoped.event",
+      });
+    });
+
+    it("inherits the level threshold", () => {
+      const { logger, lines } = createCapturingLogger({ level: "warn" });
+      logger.child({ playerId: "abc" }).info("suppressed");
+
+      expect(lines).toHaveLength(0);
+    });
+  });
+
+  describe("game event helpers", () => {
+    it("logs player connect with the active player count", () => {
+      const { logger, last } = createCapturingLogger();
+      logger.playerConnected({ playerId: "p1", activePlayers: 4 });
+
+      expect(last()).toMatchObject({
+        event: GAME_EVENTS.PLAYER_CONNECTED,
+        level: "info",
+        playerId: "p1",
+        activePlayers: 4,
+      });
+    });
+
+    it("logs player disconnect including whether they were IT", () => {
+      const { logger, last } = createCapturingLogger();
+      logger.playerDisconnected({
+        playerId: "p1",
+        activePlayers: 3,
+        wasIt: true,
+      });
+
+      expect(last()).toMatchObject({
+        event: GAME_EVENTS.PLAYER_DISCONNECTED,
+        playerId: "p1",
+        activePlayers: 3,
+        wasIt: true,
+      });
+    });
+
+    it("logs a successful tag with both player ids", () => {
+      const { logger, last } = createCapturingLogger();
+      logger.playerTagged({ taggerId: "p1", taggedId: "p2", mode: "tag" });
+
+      expect(last()).toMatchObject({
+        event: GAME_EVENTS.PLAYER_TAGGED,
+        level: "info",
+        taggerId: "p1",
+        taggedId: "p2",
+        mode: "tag",
+      });
+    });
+
+    it("logs a rejected tag at warn level with a reason", () => {
+      const { logger, last } = createCapturingLogger();
+      logger.tagRejected({
+        taggerId: "p1",
+        taggedId: "p2",
+        reason: "tagger_not_it",
+      });
+
+      expect(last()).toMatchObject({
+        event: GAME_EVENTS.TAG_REJECTED,
+        level: "warn",
+        reason: "tagger_not_it",
+      });
+    });
+
+    it("logs a score change with a computed delta", () => {
+      const { logger, last } = createCapturingLogger();
+      logger.scoreChanged({
+        playerId: "p1",
+        previousScore: 2,
+        newScore: 3,
+        reason: "tag",
+      });
+
+      expect(last()).toMatchObject({
+        event: GAME_EVENTS.SCORE_CHANGED,
+        playerId: "p1",
+        previousScore: 2,
+        newScore: 3,
+        delta: 1,
+        reason: "tag",
+      });
+    });
+
+    it("logs game start and end", () => {
+      const { logger, records } = createCapturingLogger();
+      logger.gameStarted({ mode: "tag", itPlayerId: "p1", playerCount: 2 });
+      logger.gameEnded({ mode: "tag", durationMs: 60000, playerCount: 2 });
+
+      const [started, ended] = records();
+      expect(started).toMatchObject({
+        event: GAME_EVENTS.GAME_STARTED,
+        mode: "tag",
+        itPlayerId: "p1",
+        playerCount: 2,
+      });
+      expect(ended).toMatchObject({
+        event: GAME_EVENTS.GAME_ENDED,
+        durationMs: 60000,
+      });
+    });
+
+    it("defines a distinct stable key for every game event", () => {
+      const keys = Object.values(GAME_EVENTS);
+      expect(new Set(keys).size).toBe(keys.length);
+      keys.forEach((key) => expect(key).toMatch(/^[a-z]+\.[a-z_]+$/));
+    });
+  });
+
+  describe("default transport", () => {
+    it("writes to console.log when no transport is supplied", () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      createLogger().info("console.event", { a: 1 });
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(spy.mock.calls[0][0] as string)).toMatchObject({
+        event: "console.event",
+        a: 1,
+      });
+
+      spy.mockRestore();
+    });
+  });
+});

--- a/src/__tests__/server.port.test.ts
+++ b/src/__tests__/server.port.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { resolvePort, DEFAULT_PORT } from "../../server/port.js";
+
+describe("resolvePort", () => {
+  it("falls back to the default when PORT is unset", () => {
+    expect(resolvePort(undefined)).toBe(DEFAULT_PORT);
+  });
+
+  it("falls back to the default when PORT is empty", () => {
+    expect(resolvePort("")).toBe(DEFAULT_PORT);
+  });
+
+  it("accepts a valid port string", () => {
+    expect(resolvePort("8080")).toBe(8080);
+  });
+
+  it("accepts the boundary values 1 and 65535", () => {
+    expect(resolvePort("1")).toBe(1);
+    expect(resolvePort("65535")).toBe(65535);
+  });
+
+  it("rejects a non-numeric PORT instead of silently producing NaN", () => {
+    expect(() => resolvePort("abc")).toThrow(/Invalid PORT "abc"/);
+  });
+
+  it("rejects a non-integer PORT", () => {
+    expect(() => resolvePort("3000.5")).toThrow(/Invalid PORT/);
+  });
+
+  it("rejects a PORT of 0 or below", () => {
+    expect(() => resolvePort("0")).toThrow(/Invalid PORT/);
+    expect(() => resolvePort("-1")).toThrow(/Invalid PORT/);
+  });
+
+  it("rejects a PORT above 65535", () => {
+    expect(() => resolvePort("65536")).toThrow(/Invalid PORT/);
+  });
+});

--- a/src/__tests__/server.tagAuthorization.test.ts
+++ b/src/__tests__/server.tagAuthorization.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { authorizeTag } from "../../server/tagAuthorization.js";
+
+const activeTagGame = (itPlayerId: string) => ({
+  isActive: true,
+  mode: "tag",
+  itPlayerId,
+});
+
+const clients = { p1: {}, p2: {}, p3: {} };
+
+describe("authorizeTag", () => {
+  it("allows the current IT player to tag a known, different player", () => {
+    expect(
+      authorizeTag({
+        taggerId: "p1",
+        taggedId: "p2",
+        gameState: activeTagGame("p1"),
+        clients,
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it("rejects a client impersonating the IT player via a spoofed taggerId", () => {
+    // The caller always binds taggerId to client.id, so this exercises the
+    // case where the sending socket ("p2") is not actually IT ("p1" is) —
+    // the regression this function exists to prevent.
+    const decision = authorizeTag({
+      taggerId: "p2",
+      taggedId: "p1",
+      gameState: activeTagGame("p1"),
+      clients,
+    });
+
+    expect(decision).toEqual({ ok: false, reason: "tagger_not_it" });
+  });
+
+  it("rejects a self-tag", () => {
+    expect(
+      authorizeTag({
+        taggerId: "p1",
+        taggedId: "p1",
+        gameState: activeTagGame("p1"),
+        clients,
+      }),
+    ).toEqual({ ok: false, reason: "self_tag" });
+  });
+
+  it("rejects an unknown tagged player", () => {
+    expect(
+      authorizeTag({
+        taggerId: "p1",
+        taggedId: "ghost",
+        gameState: activeTagGame("p1"),
+        clients,
+      }),
+    ).toEqual({ ok: false, reason: "unknown_player" });
+  });
+
+  it("rejects a taggedId that only resolves via the prototype chain", () => {
+    // Object.prototype.hasOwnProperty guards against "__proto__" /
+    // "constructor" / "toString" resolving truthy against a plain object.
+    expect(
+      authorizeTag({
+        taggerId: "p1",
+        taggedId: "__proto__",
+        gameState: activeTagGame("p1"),
+        clients,
+      }),
+    ).toEqual({ ok: false, reason: "unknown_player" });
+
+    expect(
+      authorizeTag({
+        taggerId: "p1",
+        taggedId: "constructor",
+        gameState: activeTagGame("p1"),
+        clients,
+      }),
+    ).toEqual({ ok: false, reason: "unknown_player" });
+  });
+
+  it("rejects when no tag game is active", () => {
+    expect(
+      authorizeTag({
+        taggerId: "p1",
+        taggedId: "p2",
+        gameState: { isActive: false, mode: "none", itPlayerId: null },
+        clients,
+      }),
+    ).toEqual({ ok: false, reason: "no_active_tag_game" });
+  });
+
+  it("rejects when the active game is a different mode", () => {
+    expect(
+      authorizeTag({
+        taggerId: "p1",
+        taggedId: "p2",
+        gameState: { isActive: true, mode: "collectible", itPlayerId: "p1" },
+        clients,
+      }),
+    ).toEqual({ ok: false, reason: "no_active_tag_game" });
+  });
+
+  it("rejects when taggedId is missing", () => {
+    expect(
+      authorizeTag({
+        taggerId: "p1",
+        taggedId: undefined,
+        gameState: activeTagGame("p1"),
+        clients,
+      }),
+    ).toEqual({ ok: false, reason: "unknown_player" });
+  });
+});


### PR DESCRIPTION
## Problem

`ROADMAP.md` has carried "Define the multiplayer readiness gate" as an open Q2 item, and `TASKS.md` noted that "structured logging, graceful shutdown, and operational visibility have not been fully verified." That left no answer to a simple question: **is the server actually ready to host multiplayer?** Multiplayer Tag can't responsibly move out of `[planned]` while the answer is a judgement call.

This PR turns that into a concrete pass/fail gate with four criteria, each with a runnable acceptance check, and implements what was missing so the repo passes its own bar.

## Approach

`docs/MULTIPLAYER_GATE.md` is the deliverable that matters — it defines each criterion, why it exists, and the exact command that proves it. The code exists to make the checks pass.

The server-side work is factored into three small, pure-ish modules rather than more inline logic in `server/index.js`:

- **`server/cors.js`** — one allow-list, applied to both the Express app and the Socket.io handshake.
- **`server/logger.js`** — structured JSON logging with a stable event catalogue.
- **`server/health.js`** — the `/health` payload as a pure function of a state snapshot.

Each ships with a sibling `.d.ts`, matching the existing `server/profanity.js` + `profanity.d.ts` convention, so the Vitest suite can import them from TypeScript without a build step or new dependency.

## Two latent bugs found while validating

Neither was the assigned work, but both make the gate meaningless if left in place.

**1. `/health` was unreachable.** The SPA fallback was mounted *before* the API router. `req.accepts("html")` is truthy for `Accept: */*` — which curl, the Docker `HEALTHCHECK`, and Render's probe all send — so every `/health` request was answered with `index.html` and the handler never ran. The platform health check was "passing" while reporting nothing about the server. Confirmed empirically before the fix:

```
status 404
<pre>Error: ENOENT: no such file or directory, stat '/app/dist/index.html'</pre>
```

The router is now mounted first, with a comment and a documented requirement in the gate doc so a future middleware reorder doesn't silently reintroduce it.

**2. The CORS wildcard matcher didn't escape regex metacharacters.** `allowedOrigin.replace(/\*/g, ".*")` compiled `https://darkmoon-dev.netlify.app` into a pattern where every `.` matched any character, so look-alike hosts like `https://darkmoon-devXnetlify.app` were accepted. Patterns are now escaped except for `*` and anchored at both ends, with regression tests for both cases.

## Design decisions worth a second look

- **`degraded` returns HTTP 200, not 503.** A server at capacity is still healthy; returning 503 would make the platform cycle it precisely when it's busiest. Only a server that can't produce a report at all returns 503.
- **Player counts come from the tracked `clients` map, not `engine.clientsCount`.** Socket.io hasn't decremented its counter yet inside a `disconnect` handler — the first version of this logged `activePlayers: 1` on the last player's disconnect. The map is accurate on both edges.
- **CORS rejection returns 403, not the default 500.** The `cors` package hands the error to Express's default handler, which prints an unstructured stack trace — that alone would break the "all output is JSON" criterion. Rejections are now tagged with an error code and converted to a clean 403 by a central error handler.
- **Chat message bodies are not logged**, only `messageLength`. Player-authored content shouldn't land in operational logs.
- **Reserved log keys can't be overwritten by context**, so game data containing a `level` field can't corrupt a record.
- **Minimal server-side score tracking was added** (tagger +1 per successful tag) because "log score changes" is meaningless with nothing to log. `scores` is added to the `player-tagged` broadcast as an additive field; no client currently listens to that event, so nothing breaks.

## Verification

Full suite, typecheck, and lint in Docker (host has no Node):

```
TYPECHECK_OK
LINT_OK
LINTALL_OK
 Test Files  77 passed (77)
      Tests  627 passed | 5 skipped (632)
```

74 test files → 77; 69 new tests. No existing test was modified.

The deployment and observability criteria were verified against the actual production image, not just unit tests:

```
$ docker build --target runner -t darkmoon-prod .
$ docker inspect -f '{{.State.Health.Status}}' gate-prod
healthy

$ docker kill --signal=SIGTERM gate-prod
exit code: 0

{"service":"darkmoon-server","port":4444,"nodeEnv":"production",...,"level":"info","event":"server.started"}
{"service":"darkmoon-server","signal":"SIGTERM","activePlayers":0,"uptimeSeconds":58,...,"event":"server.shutdown"}
```

`/health` with a live socket connected, and CORS enforcement end-to-end:

```
{"status":"ok","uptimeSeconds":16,"activePlayers":1,"activeGames":0,"maxPlayers":64,...}

Origin: https://darkmoon-dev.netlify.app              → 200, ACAO echoed
Origin: https://deploy-preview-42--darkmoon-dev...    → 200, ACAO echoed
Origin: https://evil.example                          → 403 {"error":"Origin not allowed"}
```

## Known gaps and limitations

Being explicit about what this does **not** establish:

- **The route-ordering fix has no automated test.** The `/health` middleware-order regression — the most consequential bug here — is verified manually via Docker, not in CI. An automated guard needs the Express app exported separately from `app.listen()`, or a `supertest` dependency. Neither felt in scope, but it means the bug could return without a red test. The gate doc calls this out as an explicit requirement; that's weaker than a test.
- **`maxPlayers: 64` is a chosen default, not a load-tested one.** No capacity testing was done. It's a placeholder that makes `degraded` reachable and configurable, not an empirical limit.
- **`activeGames` is 0 or 1.** The server hosts a single global match. It's written as a function over game state so a future room model can report a real count without changing the `/health` contract, but today it's a boolean in disguise.
- **This gate certifies operability, not gameplay correctness.** Two known multiplayer bugs remain open in `TASKS.md` and must also close before Multiplayer Tag ships: `player-tagged` enforces no cooldown/freeze parity with the client's `GameManager`, and a disconnecting IT player doesn't hand off `itPlayerId`. Both are now *observable* (`game.tag_rejected` carries a reason, `player.disconnected` carries `wasIt`) — diagnosable, not fixed. I deliberately left the game logic alone since that work is separately scoped with its own acceptance criteria.
- **`/health` is unauthenticated** and exposes player/game counts publicly. Consistent with the current `/` status route, and low-sensitivity, but worth a conscious decision rather than an accident.
- **Reverse proxy config is documented, not deployed.** The nginx/Caddy snippets in the gate doc are correct for Socket.io's upgrade requirements but haven't been exercised against a real proxy — Render (the current target) handles upgrades natively. I also noted that `app.set("trust proxy", 1)` will be needed if the app ever sits behind a proxy setting `X-Forwarded-For`, or `express-rate-limit` will bucket every client into one bucket. That change is *not* made here since it's wrong for the current deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a detailed `/health` endpoint reporting server status, uptime, active players, active games, and version.
  * Added configurable CORS policies with scoped wildcard origin support.
  * Added structured server logging for operational and gameplay events.
  * Player scores now update safely during tagging and reset when games start or end.
  * Added graceful shutdown handling and validated port configuration.

* **Bug Fixes**
  * Improved container health checks to validate the health response.
  * Prevented unauthorized, self, and unknown-player tagging.
  * Corrected API routing so health checks are not served the app shell.

* **Documentation**
  * Expanded API, architecture, deployment, and multiplayer readiness documentation.
  * Added configuration guidance for server, CORS, logging, health, and profanity settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->