### PR TITLE
docs: refresh METRICS.md coverage/test figures

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -2,28 +2,28 @@
 
 ## Core Metrics
 
-| Metric           | Value  | Notes                                                    |
-| ---------------- | ------ | -------------------------------------------------------- |
-| Code Coverage    | 70.65% | Measured by Vitest v8 (Docker). Branches: 54.49%, Functions: 75.65%, Lines: 73.24% |
-| Build Time       | ~5s    | Vite production build (measured on M1 Mac, Mar 2026)     |
-| Bundle Size      | 2.1MB  | Measured: `dist/` output, Mar 2026                       |
-| Test Files       | 74     | Vitest unit and integration tests                        |
-| Test Cases       | 563    | Total test cases (558 passing, 5 skipped)                |
-| Source Files     | ~80    | TypeScript/TSX files in src/ (excluding tests and types) |
-| Lines of Code    | ~10K   | Estimated (excluding node_modules and generated files)   |
-| API Routes       | 1      | WebSocket server with /health endpoint                   |
-| Dependencies     | 10     | Production dependencies (see package.json)               |
-| Dev Dependencies | 31     | Development and testing tools                            |
+| Metric           | Value  | Notes                                                                                          |
+| ---------------- | ------ | ---------------------------------------------------------------------------------------------- |
+| Code Coverage    | 71.18% | Measured by Vitest v8 (Docker, 2026-08-28). Branches: 55.85%, Functions: 76.65%, Lines: 73.65% |
+| Build Time       | ~5s    | Vite production build (measured on M1 Mac, Mar 2026)                                           |
+| Bundle Size      | 2.1MB  | Measured: `dist/` output, Mar 2026                                                             |
+| Test Files       | 79     | Vitest unit and integration tests                                                              |
+| Test Cases       | 659    | Total test cases (654 passing, 5 skipped)                                                      |
+| Source Files     | ~80    | TypeScript/TSX files in src/ (excluding tests and types)                                       |
+| Lines of Code    | ~10K   | Estimated (excluding node_modules and generated files)                                         |
+| API Routes       | 1      | WebSocket server with /health endpoint                                                         |
+| Dependencies     | 10     | Production dependencies (see package.json)                                                     |
+| Dev Dependencies | 31     | Development and testing tools                                                                  |
 
 ## Health
 
-| Metric           | Value      | Notes                                                                        |
-| ---------------- | ---------- | ---------------------------------------------------------------------------- |
-| Open Issues      | 0          | As of Mar 2026                                                               |
-| Open PRs         | 0          | As of Mar 2026                                                               |
-| Health Score     | 100        | Overseer calculated, Mar 2026                                                |
-| Last Updated     | 2026-08-22 | Test suite expanded to 75 files / 558 passing; grenade arc, ARCHITECTURE.md, API.md added |
-| CI Status        | ✅ Passing | All tests passing, build successful                                          |
-| TypeScript       | ✅ Strict  | Strict mode enabled, 0 type errors                                           |
-| Linting          | ✅ Clean   | ESLint with --max-warnings=0                                                 |
-| Pre-commit Hooks | ✅ Active  | Husky + lint-staged enforcing quality gates                                  |
+| Metric           | Value      | Notes                                                                                                                                     |
+| ---------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Open Issues      | 0          | As of Mar 2026                                                                                                                            |
+| Open PRs         | 0          | As of Mar 2026                                                                                                                            |
+| Health Score     | 100        | Overseer calculated, Mar 2026                                                                                                             |
+| Last Updated     | 2026-08-28 | Multiplayer readiness gate merged (#418): logger/cors/health/port/tagAuthorization modules, test suite expanded to 79 files / 654 passing |
+| CI Status        | ✅ Passing | All tests passing, build successful                                                                                                       |
+| TypeScript       | ✅ Strict  | Strict mode enabled, 0 type errors                                                                                                        |
+| Linting          | ✅ Clean   | ESLint with --max-warnings=0                                                                                                              |
+| Pre-commit Hooks | ✅ Active  | Husky + lint-staged enforcing quality gates                                                                                               |


### PR DESCRIPTION
## Problem

`METRICS.md` still showed the pre-#418 baseline (70.65% coverage, 74 test files, 563 test cases, "Last Updated 2026-08-22") after the multiplayer readiness gate PR merged. The PR touched `TASKS.md` and `docs/MULTIPLAYER_GATE.md` but never `METRICS.md`, so it drifted stale immediately on merge.

## Fix

Re-measured fresh against current `main` (post-#418) in Docker: `docker build --target test` then `npx vitest run --config ./config/vitest.config.ts --configLoader runner --coverage`.

- Coverage: 71.18% statements / 55.85% branches / 76.65% functions / 73.65% lines
- 79 test files, 659 test cases (654 passing, 5 skipped)
- Dependency/dev-dependency counts (10 / 31) were re-checked against `package.json` and are unchanged, so left as-is.

## Verification

- `npx vitest run --coverage` in Docker: 79 files / 654 passed / 5 skipped (see numbers above)
- `npm run lint:all` in Docker: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)