### PR TITLE
docs: state-of-union refresh

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -139,7 +139,11 @@ Status guide: `[shipped]` is live today, `[in-progress]` is partially implemente
 ### 🔐 Server & Networking
 
 - **WebSocket Server**: Express + Socket.io for real-time communication
-- **Health Checks**: `/health` endpoint for monitoring
-- **CORS Configuration**: Environment-based origin allowlist
+- **Health Checks**: `/health` endpoint for monitoring — pure-function payload (`server/health.js`) reports status/uptime/active players/games and degrades to `degraded` (still HTTP 200) at capacity rather than failing
+- **CORS Configuration**: Environment-based origin allowlist shared identically between the HTTP app and the Socket.io handshake (`server/cors.js`); wildcard entries are scoped to a single DNS label (rejects cross-label spoofing) and a bare `ALLOWED_ORIGINS=*` is dropped rather than combined with `credentials: true`
+- **Structured JSON Logging**: Every server log line is one JSON object (`server/logger.js`) with a stable `event` key; child loggers carry permanent bound fields that a call-site context key cannot silently overwrite
+- **Graceful Shutdown**: `SIGTERM` drains connections and exits `0` within 10s, verified against a `server.shutdown` log record — required for zero-downtime deploys on platforms that send `SIGTERM` on scale-down
+- **player-tagged Authorization**: the tag-mode socket event binds the acting player to the authenticated socket connection (`client.id`) rather than trusting a client-supplied ID, and rejects self-tags — prevents a connected client from impersonating the current IT player
+- **Multiplayer Readiness Gate**: four criteria (deployment, CORS, logging, observability) each with a runnable acceptance check documented in `docs/MULTIPLAYER_GATE.md`; all four pass
 - **Connection Management**: Graceful disconnect handling
 - **Error Recovery**: Automatic reconnection with exponential backoff

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Last Updated: 2026-08-22
+Last Updated: 2026-08-28
 
 ## 2025 Q4 ✅
 
@@ -28,13 +28,14 @@ Last Updated: 2026-08-22
 
 - [x] Define the multiplayer readiness gate around deployment, CORS, logging, shutdown behavior, and operational visibility. _(completed 2026-08-27; see `docs/MULTIPLAYER_GATE.md` — all four criteria pass)_
 - [x] Add `ARCHITECTURE.md` and `API.md`. _(completed 2026-08-21; `docs/ARCHITECTURE.md` and `docs/API.md` exist)_
-- [ ] Measured `METRICS.md` refresh. _(estimates remain; in-progress)_
+- [x] Measured `METRICS.md` refresh. _(completed 2026-08-28: 71.18% statements / 55.85% branches / 76.65% functions / 73.65% lines, 79 test files / 659 cases, measured in Docker post-#418 merge — PR #419)_
 - [ ] Re-scope the remaining refactor backlog against the current codebase.
 
 ## 2026 Q3 (In Progress)
 
-- [ ] Ship the first validated multiplayer-capable experience after the readiness gate is met.
+- [ ] Ship the first validated multiplayer-capable experience after the readiness gate is met. Readiness gate itself is done (all four criteria pass, PR #418); remaining blockers are the two gameplay-parity gaps tracked in TASKS.md (tag cooldown/freeze window, IT-player disconnect handoff).
 - [ ] Revisit additional gameplay modes only after the live foundation is stable.
+- [ ] **CORS wildcard/allowlist operator doc** — new idea (2026-08-28): the readiness gate work fixed two subtle CORS bugs (a bare `ALLOWED_ORIGINS=*` combined with `credentials:true`, and a wildcard that matched across DNS labels instead of within one) that would be easy for a future deploy to reintroduce by hand-editing `ALLOWED_ORIGINS`. A short "how to safely add an origin" note in `docs/MULTIPLAYER_GATE.md` — with the drop-a-bare-wildcard and single-label-only rules stated plainly — would prevent the next person (or agent) from silently reverting the fix in `.env`.
 
 ## 2026 Q4 (Exploratory)
 


### PR DESCRIPTION
## Problem

ROADMAP.md's "Measured METRICS.md refresh" item still said "in-progress" after it shipped (PR #419), and FEATURES.md never documented the readiness-gate server work from PR #418 (health payload, shared CORS policy, structured logging, graceful shutdown, tag authorization).

## Fix

- Marked the METRICS.md refresh done with the actual measured numbers.
- Added the readiness-gate features to FEATURES.md's Server & Networking section.
- Added one new idea: a short operator-facing note on safely adding CORS origins, since the readiness gate fixed two subtle wildcard bugs that a future hand-edit to `ALLOWED_ORIGINS` could silently reintroduce.

Docs-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded server and networking documentation with health checks, CORS behavior, structured logging, graceful shutdown, socket authorization, and multiplayer readiness requirements.
  * Updated the project roadmap with the latest date, completed metrics refresh, multiplayer milestone status, remaining parity work, and an operator documentation task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->